### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python package
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/patman15/aiobmsble/security/code-scanning/1](https://github.com/patman15/aiobmsble/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the least privileges required for the workflow to function. Since the workflow only checks out the repository, sets up Python, installs dependencies, lints, and runs tests, it only requires `contents: read` permissions. This ensures that the workflow cannot perform any unintended write operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
