### PR TITLE
Fix CW20 plugin decoding and add unit tests

### DIFF
--- a/aiobmsble/bms/cw20_bms.py
+++ b/aiobmsble/bms/cw20_bms.py
@@ -1,0 +1,108 @@
+"""Plugin to support ATORCH CW20 DC Meter (Smart Shunt)."""
+
+import logging
+from typing import Final
+
+from bleak.backends.characteristic import BleakGATTCharacteristic
+from bleak.backends.device import BLEDevice
+from bleak.uuids import normalize_uuid_str
+
+from aiobmsble.basebms import (
+    BaseBMS,
+    BMSdp,
+    BMSsample,
+    BMSvalue,
+    MatcherPattern,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class BMS(BaseBMS):
+    """ATORCH CW20 Smart Shunt implementation."""
+
+    INFO_LEN: Final[int] = 36  # typical CW20 frame size
+
+    _FIELDS: Final[tuple[BMSdp, ...]] = (
+        BMSdp("voltage", 4, 3, False, lambda x: x / 10.0),       # bytes 5–7, 0.1 V
+        BMSdp("current", 7, 3, False, lambda x: x / 1000.0),     # bytes 8–10, 0.001 A
+        BMSdp("capacity", 10, 3, False, lambda x: x / 1000.0),   # bytes 11–13, 0.001 Ah
+        BMSdp("energy", 13, 4, False, lambda x: x / 100.0),      # bytes 14–17, 0.01 kWh
+        BMSdp("temperature", 24, 2, False, lambda x: x),         # bytes 25–26, °C
+    )
+
+    def __init__(self, ble_device: BLEDevice, keep_alive: bool = True) -> None:
+        """Initialize CW20 members."""
+        super().__init__(ble_device, keep_alive)
+        self._data_final: bytearray = bytearray()
+
+    # --------------------
+    # Device identification
+    # --------------------
+    @staticmethod
+    def matcher_dict_list() -> list[MatcherPattern]:
+        """Provide BluetoothMatcher definition for CW20."""
+        return [
+            MatcherPattern(
+                local_name="CW20_BLE",
+                service_uuid=BMS.uuid_services()[0],
+                connectable=True,
+            )
+        ]
+
+    @staticmethod
+    def device_info() -> dict[str, str]:
+        """Return device information for the shunt."""
+        return {"manufacturer": "ATORCH", "model": "CW20 DC Meter"}
+
+    @staticmethod
+    def uuid_services() -> list[str]:
+        """Return list of 128-bit UUIDs of services required by CW20."""
+        return [normalize_uuid_str("ffe0")]
+
+    @staticmethod
+    def uuid_rx() -> str:
+        """UUID of characteristic that provides notifications."""
+        return "ffe1"
+
+    @staticmethod
+    def uuid_tx() -> str:
+        """UUID of characteristic that allows writes (not needed here)."""
+        return ""
+
+    @staticmethod
+    def _calc_values() -> frozenset[BMSvalue]:
+        """Extra calculated values for CW20."""
+        return frozenset({"power"})
+
+    # --------------------
+    # Data handling
+    # --------------------
+    def _notification_handler(
+        self, _sender: BleakGATTCharacteristic, data: bytearray
+    ) -> None:
+        """Handle incoming BLE notifications from CW20."""
+        if not data.startswith(b"\xFF\x55"):
+            return
+
+        if len(data) >= BMS.INFO_LEN:
+            self._data_final = data
+            _LOGGER.debug("CW20 RX frame: %s", data.hex())
+        else:
+            _LOGGER.debug("CW20 RX frame too short: %s", data.hex())
+
+    async def _async_update(self) -> BMSsample:
+        """Update shunt status information."""
+        data: BMSsample = {}
+
+        if not self._data_final:
+            return data
+
+        # Decode основні поля
+        data = BMS._decode_data(BMS._FIELDS, self._data_final)
+
+        # Додатково рахуємо power = V * A
+        if "voltage" in data and "current" in data:
+            data["power"] = round(data["voltage"] * data["current"], 2)
+
+        return data

--- a/tests/test_cw20.py
+++ b/tests/test_cw20.py
@@ -1,0 +1,56 @@
+import pytest
+from aiobmsble.bms.cw20_bms import BMS
+
+# We use real CW20 packets captured from the device.
+# Each test vector contains:
+#   - voltage (V)
+#   - current (A)
+#   - capacity (Ah)
+#   - energy (kWh)
+#
+# Note:
+# - Energy is a cumulative field and may vary slightly between frames,
+#   so we allow a wider absolute tolerance (±0.5).
+# - Voltage, current, and capacity should match very closely, so we
+#   use a strict relative tolerance (1e-3) and a small absolute tolerance.
+
+
+@pytest.mark.parametrize(
+    "hex_packet, expected",
+    [
+        (
+            # Example 1: Voltage ≈ 339.6 V, Current ≈ 3.575 A,
+            # Capacity ≈ 8.333 Ah, Energy ≈ 28.63 kWh
+            "ff550102000d44000df700208d00000b2f000064000000000020003b1c1d3c0000000023",
+            {"voltage": 339.6, "current": 3.575, "capacity": 8.333, "energy": 28.63},
+        ),
+        (
+            # Example 2: Voltage ≈ 348.0 V, Current ≈ 3.545 A,
+            # Capacity ≈ 8.333 Ah, Energy ≈ 28.63 kWh
+            "ff550102000d98000dd900208d00000b2f000064000000000020003b1c213c0000000023",
+            {"voltage": 348.0, "current": 3.545, "capacity": 8.333, "energy": 28.63},
+        ),
+        (
+            # Example 3: Voltage ≈ 344.0 V, Current ≈ 3.572 A,
+            # Capacity ≈ 8.334 Ah, Energy ≈ 28.63 kWh
+            "ff550102000d70000df400208e00000b2f000064000000000021003b1c263c0000000023",
+            {"voltage": 344.0, "current": 3.572, "capacity": 8.334, "energy": 28.63},
+        ),
+    ],
+)
+def test_cw20_decode(hex_packet, expected):
+    """Test decoding of real CW20 frames."""
+    # Convert the hex string into raw bytes
+    frame = bytearray.fromhex(hex_packet)
+
+    # Decode using the CW20 BMS plugin definition
+    data = BMS._decode_data(BMS._FIELDS, frame)
+
+    # Verify each expected field
+    for key, val in expected.items():
+        if key == "energy":
+            # Energy is cumulative and drifts slightly → allow wider tolerance
+            assert data[key] == pytest.approx(val, rel=1e-3, abs=0.5)
+        else:
+            # Voltage, current, capacity → strict tolerance
+            assert data[key] == pytest.approx(val, rel=1e-3, abs=1e-2)


### PR DESCRIPTION
## Summary
This PR introduces a new CW20 BMS plugin for `aiobmsble`.

- Implemented `cw20_bms.py` decoder based on real device frames.
- Added unit tests in `tests/test_cw20.py` with real-life data packets.
- Verified decoding of voltage, current, capacity, and energy values against expected outputs.

## Details
- The plugin follows the structure and coding style of existing BMS plugins.
- Test coverage added in a similar style as for other plugins.
- Test values were validated with real packet data (CW20 frames).

## Real-life test data

The CW20 plugin was tested with real BLE frames sniffed from a working CW20 BMS.  
Below is an example output from `cw20_sniffer.py`:
ff55012000ff4008360022aa0000be500006400000000023003c3b303c0000000023
ff55012000ff50008130022aa0000be500006400000000023003c3b313c0000000023
ff55012000ff4007fb0022aa0000be500006400000000022003c3b323c0000000023


## Verification
- All new tests for CW20 decoding pass successfully.
- Code style and structure are aligned with project conventions.

## Next Steps
Please review and let me know if any adjustments are needed.
<img width="1898" height="519" alt="Screenshot 2025-09-17 124302" src="https://github.com/user-attachments/assets/c38140cd-dc2e-4248-a407-016407e6deba" />
