### PR TITLE
Added name DDCK01602J-003 that works great for Vatrer 24V 200Ah battery

### DIFF
--- a/aiobmsble/bms/jbd_bms.py
+++ b/aiobmsble/bms/jbd_bms.py
@@ -72,6 +72,7 @@ class BMS(BaseBMS):
                 "AL12-*",  # Aolithium
                 "BS20*",  # BasenGreen
                 "BT  LP*",  # LANPWR
+                "DDCK01602J-003",  # Vatrer 24V 200Ah
             )
         ] + [
             MatcherPattern(


### PR DESCRIPTION
BMS info:
manufacturer: zjdy
Firmware version: 8.1
Device name: sp21s001hl21s200a

Bluetooth info:
{"name":"DDCK01602J-003","address":"xx:xx:xx:xx:xx:xx","rssi":-68,"manufacturer_data":{"37637":"3337c2a5"},"service_data":{},"service_uuids":["0000ff00-0000-1000-8000-00805f9b34fb"],"source":"2C:CF:67:2F:ED:1C","connectable":true,"time":1759354374.5967484,"tx_power":null,"raw":"020106030200ff0f094444434b30313630324a2d30303307ff05933337c2a5"}
