### PR TITLE
Add Lithionics Li3 BLE BMS support

### DIFF
--- a/aiobmsble/bms/lithionics_bms.py
+++ b/aiobmsble/bms/lithionics_bms.py
@@ -1,48 +1,174 @@
-def _feed_notify(self, data: bytes) -> list[str]:
-    """Return any complete CRLF-terminated ASCII lines."""
-    self._rx += data
-    lines: list[str] = []
-    while b"\r\n" in self._rx:
-        raw, self._rx = self._rx.split(b"\r\n", 1)
-        if not raw:
-            continue
+"""Module to support Lithionics (Li3) BLE BMS.
+
+Project: aiobmsble, https://pypi.org/p/aiobmsble/
+License: Apache-2.0, http://www.apache.org/licenses/
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from bleak.backends.characteristic import BleakGATTCharacteristic
+from bleak.backends.device import BLEDevice
+from bleak.uuids import normalize_uuid_str
+
+from aiobmsble import BMSInfo, BMSSample, MatcherPattern
+from aiobmsble.basebms import BaseBMS
+
+
+class BMS(BaseBMS):
+    """Lithionics Li3 BLE UART BMS class implementation.
+
+    Protocol summary (based on captures):
+    - BLE UART service FFE0 with characteristic FFE1 (notify + write)
+    - Write b"\\r\\n" to request data
+    - Notifications deliver CRLF-terminated ASCII CSV frames, sometimes split across multiple BLE packets.
+    - Type A example:
+        1362,340,341,341,340,37,41,0,99,000000
+      Mappings (v1):
+        - voltage: 13.62 V (centivolts)
+        - cell_voltages: 3.40..3.41 V (centivolts), 4 cells observed
+        - temps: two integer values (units assumed °C but not guaranteed)
+        - current: integer (scaling TBD)
+        - battery_level: SOC percent
+        - flags_raw: last field (string)
+    - Type B example starts with '&' and is stored as raw status line.
+    """
+
+    INFO: BMSInfo = {
+        "default_manufacturer": "Lithionics",
+        "default_model": "Li3 BLE BMS",
+    }
+
+    # BLE UART UUIDs (16-bit)
+    _SVC: Final[str] = "ffe0"
+    _CHAR: Final[str] = "ffe1"
+
+    def __init__(self, ble_device: BLEDevice, keep_alive: bool = True) -> None:
+        """Initialize private BMS members."""
+        super().__init__(ble_device, keep_alive)
+        self._rx: bytearray = bytearray()
+        self._last_sample: BMSSample = {}
+        self._last_status_line: str | None = None
+
+    @staticmethod
+    def matcher_dict_list() -> list[MatcherPattern]:
+        """Provide BluetoothMatcher definition.
+
+        IMPORTANT: FFE0/FFE1 is generic BLE UART, so we key on Li3-* name
+        to avoid mis-detecting unrelated UART devices.
+        """
+        return [
+            MatcherPattern(
+                local_name="Li3-*",
+                service_uuid=BMS.uuid_services()[0],
+                connectable=True,
+            )
+        ]
+
+    @staticmethod
+    def uuid_services() -> list[str]:
+        """Return list of 128-bit UUIDs of services required by BMS."""
+        return [normalize_uuid_str(BMS._SVC)]
+
+    @staticmethod
+    def uuid_rx() -> str:
+        """Return 16-bit UUID of characteristic that provides notification/read property."""
+        return BMS._CHAR
+
+    @staticmethod
+    def uuid_tx() -> str:
+        """Return 16-bit UUID of characteristic that provides write property."""
+        # Lithionics uses the same characteristic for notify + write.
+        return BMS._CHAR
+
+    async def _fetch_device_info(self) -> BMSInfo:
+        """Fetch device information (best effort).
+
+        Li3 protocol doesn't provide a known 'device info' frame yet; return defaults.
+        """
+        return dict(BMS.INFO)
+
+    def _feed_notify(self, data: bytes) -> list[str]:
+        """Return any complete CRLF-terminated ASCII lines (reassembles packet splits)."""
+        self._rx += data
+        lines: list[str] = []
+        while True:
+            idx = self._rx.find(b"\r\n")
+            if idx < 0:
+                break
+            raw = bytes(self._rx[:idx])
+            del self._rx[: idx + 2]
+            if not raw:
+                continue
+            try:
+                lines.append(raw.decode("ascii", errors="strict"))
+            except UnicodeDecodeError:
+                continue
+        return lines
+
+    def _parse_line(self, line: str) -> None:
+        """Parse one complete Li3 CSV line and update _last_sample where applicable."""
+        line = line.strip()
+        if not line or line == "ERROR":
+            return
+
+        # Status / metadata frame
+        if line.startswith("&"):
+            self._last_status_line = line
+            return
+
+        parts = line.split(",")
+        if len(parts) < 9:
+            return
+
+        # Example:
+        # 1362,340,341,341,340,37,41,0,99,000000
+        sample: BMSSample = {}
+
         try:
-            lines.append(raw.decode("ascii", errors="strict"))
-        except UnicodeDecodeError:
-            # ignore garbage
-            continue
-    return lines
+            pack_cv = int(parts[0])
+            sample["voltage"] = pack_cv / 100.0
 
+            cell_cvs = [int(x) for x in parts[1:5]]
+            sample["cell_voltages"] = [cv / 100.0 for cv in cell_cvs]
+            sample["cell_count"] = len(cell_cvs)
 
-def _parse_line(self, line: str) -> None:
-    line = line.strip()
-    if not line or line == "ERROR":
-        return
+            # temps (units not formally confirmed; keep as raw integers)
+            sample["temp_values"] = [int(parts[5]), int(parts[6])]
 
-    if line.startswith("&"):
-        # "&,1,317,035859,0136,2300,FF05,8700"
-        self._last_status_line = line
-        return
+            # current scaling unknown; keep integer for now
+            sample["current"] = int(parts[7])
 
-    # "1362,340,341,341,340,37,41,0,99,000000"
-    parts = line.split(",")
-    if len(parts) < 9:
-        return  # or raise in debug mode
+            # SOC confirmed against app
+            sample["battery_level"] = int(parts[8])
 
-    pack_cv = int(parts[0])
-    self.voltage = pack_cv / 100.0
+            if len(parts) > 9:
+                sample["flags_raw"] = parts[9]
 
-    # heuristic: next 4 are cells (12V pack)
-    cell_cvs = [int(x) for x in parts[1:5]]
-    self.cell_voltages = [cv / 100.0 for cv in cell_cvs]
+            if self._last_status_line:
+                sample["status_raw"] = self._last_status_line
 
-    self.temp_1 = int(parts[5])
-    self.temp_2 = int(parts[6])
+        except (ValueError, IndexError):
+            return
 
-    # current scaling unknown; start with integer A
-    self.current = int(parts[7])
+        self._last_sample = sample
 
-    self.soc = int(parts[8])
+        # Unblock BaseBMS._await_reply(); content is irrelevant for this protocol.
+        self._data = bytearray(b"\x01")
+        self._data_event.set()
 
-    # optional flags
-    self.flags_raw = parts[9] if len(parts) > 9 else None
+    def _notification_handler(
+        self, _sender: BleakGATTCharacteristic, data: bytearray
+    ) -> None:
+        """Handle incoming BLE notifications."""
+        self._log.debug("RX BLE data: %s", data)
+        for line in self._feed_notify(bytes(data)):
+            self._log.debug("RX Li3 line: %s", line)
+            self._parse_line(line)
+
+    async def _async_update(self) -> BMSSample:
+        """Update battery status information."""
+        # Send poll and wait for one parsed sample via notifications.
+        await self._await_reply(b"\r\n")
+        return self._last_sample

--- a/aiobmsble/test_data/lithionics_bms.json
+++ b/aiobmsble/test_data/lithionics_bms.json
@@ -1,0 +1,17 @@
+[
+  {
+    "type": "lithionics_bms",
+    "_comments": [
+      "Lithionics Li3 BLE UART (FFE0/FFE1). Telemetry via CRLF-terminated ASCII CSV notifications on FFE1; polling via write \\r\\n."
+    ],
+    "advertisement": {
+      "local_name": "Li3-061322094",
+      "service_uuids": ["0000ffe0-0000-1000-8000-00805f9b34fb"],
+      "manufacturer_data": {},
+      "service_data": {},
+      "rssi": -60,
+      "platform_data": ["6C:79:B8:B4:4F:C0"]
+    }
+  }
+]
+

--- a/tests/bms/test_lithionics_bms.py
+++ b/tests/bms/test_lithionics_bms.py
@@ -1,0 +1,183 @@
+"""Test the Lithionics (Li3) BMS implementation."""
+
+from collections.abc import Buffer
+from uuid import UUID
+
+from bleak.backends.characteristic import BleakGATTCharacteristic
+
+from aiobmsble.bms.lithionics_bms import BMS
+from tests.bluetooth import generate_ble_device
+from tests.conftest import MockBleakClient
+
+
+class MockLithionicsBleakClient(MockBleakClient):
+    """Emulate a Lithionics Li3 BLE UART client.
+
+    When the BMS writes b"\\r\\n", the device sends CRLF-terminated ASCII CSV frames
+    over notifications on the same characteristic. Frames may arrive split across
+    multiple notifications.
+    """
+
+    async def write_gatt_char(
+        self,
+        char_specifier: BleakGATTCharacteristic | int | str | UUID,
+        data: Buffer,
+        response: bool | None = None,
+    ) -> None:
+        await super().write_gatt_char(char_specifier, data, response)
+        assert self._notify_callback is not None
+
+        # Only respond to the polling write
+        if bytes(data) != b"\r\n":
+            return
+
+        # Type A telemetry (split into 2 packets like real BLE often does)
+        part1 = b"1362,340,341,341,340,37,41,0,99,000000"
+        part2 = b"\r\n"
+        self._notify_callback("MockLithionicsBleakClient", bytearray(part1[:20]))
+        self._notify_callback("MockLithionicsBleakClient", bytearray(part1[20:] + part2))
+
+        # Type B status (optional)
+        self._notify_callback(
+            "MockLithionicsBleakClient",
+            bytearray(b"&,1,317,035859,0136,2300,FF05,8700\r\n"),
+        )
+
+        # occasional error line should be ignored
+        self._notify_callback("MockLithionicsBleakClient", bytearray(b"ERROR\r\n"))
+
+
+async def test_update(patch_bleak_client, keep_alive_fixture: bool) -> None:
+    """Test Lithionics BMS data update."""
+    patch_bleak_client(MockLithionicsBleakClient)
+
+    bms = BMS(generate_ble_device(), keep_alive_fixture)
+
+     # Cover static helpers (needed for 100% coverage gate)
+    assert BMS.uuid_services()
+    assert BMS.uuid_rx() == "ffe1"
+    assert BMS.uuid_tx() == "ffe1"
+    assert BMS.matcher_dict_list()
+
+
+    sample = await bms.async_update()
+
+    assert sample["voltage"] == 13.62
+    assert sample["cell_voltages"] == [3.40, 3.41, 3.41, 3.40]
+    assert sample["battery_level"] == 99
+    assert sample["cell_count"] == 4
+    assert sample["temp_values"] == [37, 41]
+    assert sample["current"] == 0
+
+    # query again to check already connected state
+    await bms.async_update()
+    assert bms.is_connected is keep_alive_fixture
+
+    await bms.disconnect()
+
+
+async def test_device_info(patch_bleak_client) -> None:
+    """Test that the BMS returns initialized dynamic device information."""
+    patch_bleak_client(MockLithionicsBleakClient)
+    bms = BMS(generate_ble_device())
+    info = await bms.device_info()
+    assert {"default_manufacturer", "default_model"}.issubset(info)
+
+async def test_parsing_edge_cases(patch_bleak_client) -> None:
+    """Cover edge cases for feed/parse logic (unicode garbage, short lines, status)."""
+
+    class EdgeCaseClient(MockBleakClient):
+        async def write_gatt_char(self, char_specifier, data, response=None) -> None:
+            await super().write_gatt_char(char_specifier, data, response)
+            assert self._notify_callback is not None
+
+            # invalid bytes before CRLF -> triggers UnicodeDecodeError path
+            self._notify_callback("EdgeCaseClient", bytearray(b"\xff\xfe\xfd\r\n"))
+
+            # short / invalid line -> len(parts) < 9 path
+            self._notify_callback("EdgeCaseClient", bytearray(b"1,2,3\r\n"))
+
+            # status line path
+            self._notify_callback(
+                "EdgeCaseClient",
+                bytearray(b"&,1,317,035859,0136,2300,FF05,8700\r\n"),
+            )
+
+            # finally a valid line so update completes
+            self._notify_callback(
+                "EdgeCaseClient",
+                bytearray(b"1362,340,341,341,340,37,41,0,99,000000\r\n"),
+            )
+
+    patch_bleak_client(EdgeCaseClient)
+    bms = BMS(generate_ble_device())
+    sample = await bms.async_update()
+    assert sample["battery_level"] == 99
+    await bms.disconnect()
+
+async def test_coverage_branches(patch_bleak_client) -> None:
+    """Hit remaining parse/feed branches to satisfy 100% coverage."""
+
+    class CoverageClient(MockBleakClient):
+        async def write_gatt_char(self, char_specifier, data, response=None) -> None:
+            await super().write_gatt_char(char_specifier, data, response)
+            assert self._notify_callback is not None
+
+            if bytes(data) != b"\r\n":
+                return
+
+            # empty line branch in _feed_notify (raw == b"")
+            self._notify_callback("CoverageClient", bytearray(b"\r\n"))
+
+            # ERROR line branch in _parse_line (early return)
+            self._notify_callback("CoverageClient", bytearray(b"ERROR\r\n"))
+
+            # status line FIRST so the next valid sample includes status_raw
+            self._notify_callback(
+                "CoverageClient",
+                bytearray(b"&,1,317,035859,0136,2300,FF05,8700\r\n"),
+            )
+
+            # malformed numeric CSV line to trigger ValueError -> except branch (lines 152-153)
+            self._notify_callback(
+                "CoverageClient",
+                bytearray(b"1362,340,341,341,340,37,41,NOTANINT,99,000000\r\n"),
+            )
+
+            # finally a valid line so update completes (and includes status_raw)
+            self._notify_callback(
+                "CoverageClient",
+                bytearray(b"1362,340,341,341,340,37,41,0,99,000000\r\n"),
+            )
+
+    patch_bleak_client(CoverageClient)
+    bms = BMS(generate_ble_device())
+    sample = await bms.async_update()
+    assert sample["battery_level"] == 99
+    # this assertion ensures the status-branch was actually taken
+    assert "status_raw" in sample
+    await bms.disconnect()
+async def test_no_status_line_branch(patch_bleak_client) -> None:
+    """Cover the no-status_raw and no-flags_raw branches in _parse_line()."""
+
+    class NoStatusClient(MockBleakClient):
+        async def write_gatt_char(self, char_specifier, data, response=None) -> None:
+            await super().write_gatt_char(char_specifier, data, response)
+            assert self._notify_callback is not None
+            if bytes(data) != b"\r\n":
+                return
+
+            # valid line immediately, without status line AND without flags field
+            self._notify_callback(
+                "NoStatusClient",
+                bytearray(b"1362,340,341,341,340,37,41,0,99\r\n"),
+            )
+
+    patch_bleak_client(NoStatusClient)
+    bms = BMS(generate_ble_device())
+    sample = await bms.async_update()
+    assert sample["battery_level"] == 99
+    assert "status_raw" not in sample
+    assert "flags_raw" not in sample
+    await bms.disconnect()
+


### PR DESCRIPTION
This PR adds initial support for Lithionics Li3 BLE BMS devices.

- Implements Lithionics Li3 BLE UART protocol (FFE0/FFE1).
- Polls via CRLF write and parses CRLF-terminated ASCII CSV notifications.
- Exposes voltage, cell voltages, temperatures, current (raw), and SOC.
- Uses conservative detection (local_name="Li3-*") to reduce false positives on generic BLE UART devices.
- Adds test_data fixture + unit tests; full suite passes with 100% coverage.

Notes:
- Current scaling is currently treated as a raw integer pending official protocol documentation.
