### PR TITLE
Add inv_wr_mode parameter to BaseBMS, use for ABC BMS

### DIFF
--- a/aiobmsble/basebms.py
+++ b/aiobmsble/basebms.py
@@ -62,6 +62,7 @@ class BaseBMS(ABC):
         ble_device: BLEDevice,
         keep_alive: bool = True,
         logger_name: str = "",
+        inv_wr_mode: bool | None = None,
     ) -> None:
         """Initialize the BMS.
 
@@ -76,6 +77,9 @@ class BaseBMS(ABC):
                 Make sure to call `disconnect()` when done using the BMS class or better use
                 `async with` context manager (requires `keep_alive=True`).
             logger_name (str): name of the logger for the BMS instance, default: module name
+            inv_wr_mode (bool | None): initial write mode inversion setting. `None` (default)
+                enables auto-detection, `True` forces write-without-response for characteristics
+                that support both modes.
 
         """
         assert getattr(self, "_notification_handler", None) is not None, (
@@ -87,7 +91,7 @@ class BaseBMS(ABC):
         self._ble_device: Final[BLEDevice] = ble_device
         self._keep_alive: Final[bool] = keep_alive
         self.name: Final[str] = self._ble_device.name or "undefined"
-        self._inv_wr_mode: bool | None = None  # invert write mode (WNR <-> W)
+        self._inv_wr_mode: bool | None = inv_wr_mode  # invert write mode (WNR <-> W)
         logger_name = logger_name or self.__class__.__module__
         self._log: Final[BaseBMS._PrefixAdapter] = BaseBMS._PrefixAdapter(
             logging.getLogger(f"{logger_name}"),

--- a/aiobmsble/bms/abc_bms.py
+++ b/aiobmsble/bms/abc_bms.py
@@ -58,7 +58,7 @@ class BMS(BaseBMS):
 
     def __init__(self, ble_device: BLEDevice, keep_alive: bool = True) -> None:
         """Initialize BMS."""
-        super().__init__(ble_device, keep_alive)
+        super().__init__(ble_device, keep_alive, inv_wr_mode=True)
         self._msg: dict[int, bytes] = {}
         self._exp_reply: set[int] = set()
 

--- a/aiobmsble/bms/abc_bms.py
+++ b/aiobmsble/bms/abc_bms.py
@@ -58,7 +58,7 @@ class BMS(BaseBMS):
 
     def __init__(self, ble_device: BLEDevice, keep_alive: bool = True) -> None:
         """Initialize BMS."""
-        super().__init__(ble_device, keep_alive, inv_wr_mode=True)
+        super().__init__(ble_device, keep_alive, inv_wr_mode=False)
         self._msg: dict[int, bytes] = {}
         self._exp_reply: set[int] = set()
 

--- a/tests/bms/test_abc_bms.py
+++ b/tests/bms/test_abc_bms.py
@@ -97,6 +97,12 @@ class MockABCBleakClient(MockBleakClient):
             await asyncio.sleep(0)
 
 
+def test_inv_wr_mode() -> None:
+    """Verify ABC BMS forces write-without-response mode."""
+    bms = BMS(generate_ble_device())
+    assert bms._inv_wr_mode is True
+
+
 async def test_update(
     patch_bleak_client, patch_bms_timeout, keep_alive_fixture: bool
 ) -> None:

--- a/tests/bms/test_abc_bms.py
+++ b/tests/bms/test_abc_bms.py
@@ -100,7 +100,7 @@ class MockABCBleakClient(MockBleakClient):
 def test_inv_wr_mode() -> None:
     """Verify ABC BMS forces write-without-response mode."""
     bms = BMS(generate_ble_device())
-    assert bms._inv_wr_mode is True
+    assert bms._inv_wr_mode is False
 
 
 async def test_update(

--- a/tests/test_basebms.py
+++ b/tests/test_basebms.py
@@ -489,6 +489,15 @@ async def test_wr_mode_reset(
     assert bms._inv_wr_mode is None
 
 
+def test_inv_wr_mode_parameter() -> None:
+    """Check that inv_wr_mode parameter sets _inv_wr_mode on construction."""
+    bms: MinTestBMS = MinTestBMS(generate_ble_device())
+    assert bms._inv_wr_mode is None
+
+    bms_inv: MinTestBMS = MinTestBMS(generate_ble_device(), inv_wr_mode=True)
+    assert bms_inv._inv_wr_mode is True
+
+
 def test_get_bms_module() -> None:
     """Check that basebms and dummy_bms return correct module name."""
     assert BaseBMS.get_bms_module() == "aiobmsble.basebms"


### PR DESCRIPTION
  ABC BMS firmware rejects write-with-response (GATT status=3), causing unnecessary errors during auto-detection. Add a base class parameter to allow subclasses to skip auto-detection and set the write mode directly. This behavior applies to all battery models which are used by the official ABC-BMS app (ABC-*, SOK-*, NB-*, Hoover).

  <!--
    Thanks for contributing to this project!
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  -->

  ## Checklist
  <!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    This is simply a reminder of what I'm are going to look for before merging
    your code. Please see the CONTRIBUTING.md for more information.
  -->

  ### [Code Requirements][coding-guide]
  - [x] There is no commented out code in this PR.
  - [x] The code has been formatted according to Ruff. (`ruff check .`)
  - [x] The code passes code quality checks of mypy. (`mypy .`)
  - [x] The code passes spelling checks of codespell. (`codespell .`)

  ### [Architecture][architecture-guide] for new BMS types
  - [ ] The `BMSSample` structure is being filled with all available BMS data.
  - [ ] BMS frames are checked for validity, e.g. CRC, length, allowed type.
  - [ ] A recorded BLE advertisement has been added for testing.
  - [ ] The code does not require persistent values.

  _(N/A — no new BMS type added)_

  ### Testing
  - [x] Local tests pass and coverage is 100% branch.
  - [x] Tests have been added to verify that the new code works.
  - [x] Tests use recorded data from the BMS, i.e. test data shall not be generated.

  ### Contributing
  - [ ] Especially, for new BMSs, feel free to add your nickname to the `authors` list in `pyproject.toml`
  - [x] I agree that the [project license][LICENSE] is used for my contribution

  [contribution-guide]: https://github.com/patman15/aiobmsble/tree/main?tab=contributing-ov-file
  [coding-guide]: https://github.com/patman15/aiobmsble/tree/main?tab=contributing-ov-file#coding-style-guidelines
  [architecture-guide]: https://github.com/patman15/aiobmsble/tree/main?tab=contributing-ov-file#architecture-guidelines
  [BMS-type]: https://github.com/patman15/aiobmsble/tree/main?tab=contributing-ov-file#how-to-qualify-as-a-bms
  [LICENSE]: https://github.com/patman15/aiobmsble/blob/main/LICENSE
