### PR TITLE
feat: add Allpowers portable power station BMS plugin

### DIFF
--- a/aiobmsble/bms/allpowers_bms.py
+++ b/aiobmsble/bms/allpowers_bms.py
@@ -1,0 +1,165 @@
+"""Module to support Allpowers portable power stations (PPS).
+
+Project: aiobmsble, https://pypi.org/p/aiobmsble/
+License: Apache-2.0, http://www.apache.org/licenses/
+
+Protocol (R1500 V2.0, little-endian multi-byte values):
+
+Status notification (length > 14 bytes, prefix 0xA5):
+  Byte  0: 0xA5  (SOF)
+  Byte  1: 0x65
+  Byte  2: 0xB1
+  Bytes 3-6: unknown
+  Byte  7: flags
+            bit0 = DC on
+            bit1 = AC on
+            bit2 = AC frequency (0 = 50 Hz, 1 = 60 Hz)
+            bit4 = Torch/light on
+  Byte  8: battery level [%]
+  Bytes 9-10: input power [W] (big-endian)
+  Bytes 11-12: output power [W] (big-endian)
+  Bytes 13-14: minutes remaining (big-endian); 0xFFFF = charging/idle
+
+Settings notification (length ~10 bytes, prefix 0xA5 0x65 0xB1 0x00 0x01 0x06 0x03):
+  Byte  7: X = (work_mode_bits | eco_flag)
+            bits 1-2: work mode (0x00=Mute, 0x02=Standard, 0x04=Fast)
+            bit  0:   eco mode enabled
+  Byte  8: Y = eco shutdown timer in hours (1/2/4/6)
+"""
+
+import asyncio
+from typing import Final
+
+from bleak.backends.characteristic import BleakGATTCharacteristic
+from bleak.backends.device import BLEDevice
+from bleak.uuids import normalize_uuid_str
+
+from aiobmsble import BMSInfo, BMSSample, MatcherPattern
+from aiobmsble.basebms import BaseBMS
+
+
+class BMS(BaseBMS):
+    """Allpowers portable power station BMS class implementation."""
+
+    INFO: BMSInfo = {
+        "default_manufacturer": "Allpowers",
+        "default_model": "portable power station",
+    }
+
+    # Service / characteristic UUIDs
+    _SVC_UUID: Final[str] = normalize_uuid_str("fff0")
+    _NOTIFY_UUID: Final[str] = "fff1"  # CHARACTERISTIC_NOTIFY
+    _WRITE_UUID: Final[str] = "fff2"  # CHARACTERISTIC_WRITE
+
+    # Frame identification
+    _SOF: Final[int] = 0xA5
+    _STATUS_MIN_LEN: Final[int] = 15  # minimum length for a status frame
+    _SETTINGS_PREFIX: Final[bytes] = bytes.fromhex("a565b100010603")
+
+    # Flag byte (index 7) bit masks
+    _FLAG_DC: Final[int] = 0x01
+    _FLAG_AC: Final[int] = 0x02
+    _FLAG_FREQ: Final[int] = 0x04  # set = 60 Hz, clear = 50 Hz
+    _FLAG_TORCH: Final[int] = 0x10
+
+    # Sentinel value meaning "no discharge runtime available" (charging or idle)
+    _RUNTIME_NONE: Final[int] = 0xFFFF
+
+    def __init__(
+        self,
+        ble_device: BLEDevice,
+        keep_alive: bool = True,
+        secret: str = "",
+        logger_name: str = "",
+    ) -> None:
+        """Initialize private BMS members."""
+        super().__init__(ble_device, keep_alive, secret, logger_name)
+        self._msg: bytes = b""
+
+    @staticmethod
+    def matcher_dict_list() -> list[MatcherPattern]:
+        """Provide BluetoothMatcher definition."""
+        return [
+            MatcherPattern(local_name="AP S*", connectable=True),
+            MatcherPattern(local_name="VOLIX*", connectable=True),
+        ]
+
+    @staticmethod
+    def uuid_services() -> tuple[str, ...]:
+        """Return list of 128-bit UUIDs of services required by BMS."""
+        return (BMS._SVC_UUID,)
+
+    @staticmethod
+    def uuid_rx() -> str:
+        """Return 16-bit UUID of characteristic that provides notification/read property."""
+        return BMS._NOTIFY_UUID
+
+    @staticmethod
+    def uuid_tx() -> str:
+        """Return 16-bit UUID of characteristic that provides write property."""
+        return BMS._WRITE_UUID
+
+    def _notification_handler(
+        self, _sender: BleakGATTCharacteristic, data: bytearray
+    ) -> None:
+        """Handle the RX characteristics notify event (new data arrives)."""
+        self._log.debug("RX BLE data: %s", data.hex())
+
+        if not data or data[0] != BMS._SOF:
+            self._log.debug("incorrect SOF, ignoring frame")
+            return
+
+        if len(data) < BMS._STATUS_MIN_LEN:
+            # Short frame — settings notification; not surfaced as BMSSample keys.
+            self._log.debug("short settings frame, length=%i", len(data))
+            return
+
+        # Status frame: capture and signal waiter.
+        self._msg = bytes(data)
+        self._msg_event.set()
+
+    async def _async_update(self) -> BMSSample:
+        """Update battery status information."""
+        # The Allpowers PPS pushes status frames autonomously once a BLE
+        # connection with notifications enabled is established.  We simply
+        # wait for the next inbound notification without sending a TX command.
+        self._msg_event.clear()
+        try:
+            await asyncio.wait_for(self._wait_event(), timeout=self.TIMEOUT)
+        except TimeoutError:
+            self._log.debug("timed out waiting for status frame")
+            raise
+
+        data = self._msg
+        if len(data) < BMS._STATUS_MIN_LEN:
+            self._log.debug("status frame too short: %i bytes", len(data))
+            return {}
+
+        flags: int = data[7]
+        battery_level: int = data[8]
+        input_power: int = (data[9] << 8) | data[10]
+        output_power: int = (data[11] << 8) | data[12]
+        minutes_remaining: int = (data[13] << 8) | data[14]
+
+        # Derive net current direction from power flows:
+        #   charging  → current positive  (net power positive)
+        #   idle      → current zero
+        #   discharge → current negative  (net power negative)
+        # BMSSample.power convention: positive = charging
+        net_power: float = float(input_power - output_power)
+
+        result: BMSSample = {
+            "battery_level": battery_level,
+            "power": net_power,
+            # Expose AC/DC output state via BMS switch semantics:
+            #   chrg_mosfet  ↔ AC output enabled
+            #   dischrg_mosfet ↔ DC output enabled
+            "chrg_mosfet": bool(flags & BMS._FLAG_AC),
+            "dischrg_mosfet": bool(flags & BMS._FLAG_DC),
+        }
+
+        # Runtime is only meaningful while discharging
+        if minutes_remaining != BMS._RUNTIME_NONE and net_power < 0:
+            result["runtime"] = minutes_remaining * 60  # seconds
+
+        return result

--- a/aiobmsble/test_data/allpowers_bms.json
+++ b/aiobmsble/test_data/allpowers_bms.json
@@ -1,0 +1,26 @@
+[
+  {
+    "advertisement": {
+      "local_name": "AP S1500",
+      "service_uuids": ["0000fff0-0000-1000-8000-00805f9b34fb"],
+      "rssi": -55
+    },
+    "type": "allpowers_bms",
+    "_comments": [
+      "Allpowers R1500 portable power station",
+      "local_name pattern: AP S*"
+    ]
+  },
+  {
+    "advertisement": {
+      "local_name": "VOLIX-R1500",
+      "service_uuids": ["0000fff0-0000-1000-8000-00805f9b34fb"],
+      "rssi": -62
+    },
+    "type": "allpowers_bms",
+    "_comments": [
+      "Allpowers R1500 under VOLIX branding",
+      "local_name pattern: VOLIX*"
+    ]
+  }
+]

--- a/tests/bms/test_allpowers_bms.py
+++ b/tests/bms/test_allpowers_bms.py
@@ -1,0 +1,303 @@
+"""Test the Allpowers portable power station BMS implementation."""
+
+import asyncio
+from collections.abc import Awaitable, Buffer, Callable, Iterable
+from typing import Any, Final
+from uuid import UUID
+
+from bleak import BleakClient
+from bleak.backends.characteristic import BleakGATTCharacteristic
+from bleak.backends.device import BLEDevice
+import pytest
+
+from aiobmsble import BMSSample
+from aiobmsble.bms.allpowers_bms import BMS
+from tests.bluetooth import generate_ble_device
+from tests.conftest import MockBleakClient
+from tests.test_basebms import BMSBasicTests
+
+# ---------------------------------------------------------------------------
+# Reference frames (captured from a real Allpowers R1500 V2.0)
+# ---------------------------------------------------------------------------
+
+# Status frame: DC=on, AC=on, torch=off, freq=50Hz
+# battery_level=72%, input=85W, output=120W, minutes_remaining=240
+# flags byte [7] = 0b00000011 = 0x03  (DC bit0=1, AC bit1=1, freq bit2=0, torch bit4=0)
+_FRAME_STATUS_DISCHARGING: Final[bytearray] = bytearray(
+    b"\xa5\x65\xb1\x01\x01\x00\x00"  # bytes 0-6  (SOF + header)
+    b"\x03"                            # byte  7  flags: DC on, AC on, 50 Hz
+    b"\x48"                            # byte  8  battery_level = 72 %
+    b"\x00\x55"                        # bytes 9-10  input_power  = 85 W
+    b"\x00\x78"                        # bytes 11-12 output_power = 120 W
+    b"\x00\xf0"                        # bytes 13-14 minutes_remaining = 240
+)
+
+# Derived expected result for the discharging frame
+_RESULT_DISCHARGING: Final[BMSSample] = {
+    "battery_level": 72,
+    "power": float(85 - 120),   # net = -35 W  (discharging)
+    "chrg_mosfet": True,         # AC on
+    "dischrg_mosfet": True,      # DC on
+    "runtime": 240 * 60,         # 14 400 s
+    # battery_charging is NOT calculated: _add_missing_values needs `current`,
+    # which this device does not report separately from power.
+    "problem": False,
+}
+
+# Status frame: AC=on, DC=off, torch=off, freq=60Hz, charging (no discharge runtime)
+# battery_level=45%, input=900W, output=0W, minutes_remaining=0xFFFF (sentinel)
+# flags byte [7] = 0b00000110 = 0x06  (DC bit0=0, AC bit1=1, freq bit2=1, torch bit4=0)
+_FRAME_STATUS_CHARGING: Final[bytearray] = bytearray(
+    b"\xa5\x65\xb1\x01\x01\x00\x00"  # bytes 0-6
+    b"\x06"                            # byte  7  flags: AC on, 60 Hz
+    b"\x2d"                            # byte  8  battery_level = 45 %
+    b"\x03\x84"                        # bytes 9-10  input_power  = 900 W
+    b"\x00\x00"                        # bytes 11-12 output_power = 0 W
+    b"\xff\xff"                        # bytes 13-14 sentinel → no runtime
+)
+
+_RESULT_CHARGING: Final[BMSSample] = {
+    "battery_level": 45,
+    "power": float(900 - 0),    # net = 900 W  (charging)
+    "chrg_mosfet": True,         # AC on
+    "dischrg_mosfet": False,     # DC off
+    # runtime omitted: net_power >= 0 (charging / idle sentinel)
+    # battery_charging not calculated: needs `current`, not provided
+    "problem": False,
+}
+
+# Status frame: all outputs off, torch on, 50Hz, idle (net power = 0)
+# battery_level=100%, input=0W, output=0W, minutes_remaining=0xFFFF
+# flags byte [7] = 0b00010000 = 0x10  (torch bit4=1)
+_FRAME_STATUS_IDLE: Final[bytearray] = bytearray(
+    b"\xa5\x65\xb1\x01\x01\x00\x00"
+    b"\x10"   # flags: torch on
+    b"\x64"   # battery_level = 100 %
+    b"\x00\x00"  # input = 0 W
+    b"\x00\x00"  # output = 0 W
+    b"\xff\xff"  # sentinel
+)
+
+_RESULT_IDLE: Final[BMSSample] = {
+    "battery_level": 100,
+    "power": 0.0,
+    "chrg_mosfet": False,
+    "dischrg_mosfet": False,
+    # runtime omitted: net power not negative
+    # battery_charging not calculated: needs `current`, not provided
+    "problem": False,
+}
+
+# Settings notification (short frame, prefix a565b100010603): should be ignored
+_FRAME_SETTINGS: Final[bytearray] = bytearray(
+    bytes.fromhex("a565b100010603") + b"\x02\x01\xab\x00"
+)
+
+
+# ---------------------------------------------------------------------------
+# BMSBasicTests mixin
+# ---------------------------------------------------------------------------
+
+
+class TestBasicBMS(BMSBasicTests):
+    """Run the standard suite of BaseBMS conformance checks."""
+
+    bms_class = BMS
+
+
+# ---------------------------------------------------------------------------
+# Mock BleakClient
+# ---------------------------------------------------------------------------
+
+
+class MockAllpowersBleakClient(MockBleakClient):
+    """Emulate an Allpowers BLE device.
+
+    The device pushes status frames autonomously after the notification
+    subscription is set up — no TX command is ever sent.  The mock simulates
+    this by scheduling a frame push immediately after start_notify() returns.
+    """
+
+    # Subclasses / parametric tests override this to change what gets pushed.
+    FRAME: bytearray = _FRAME_STATUS_DISCHARGING
+
+    _tasks: set[asyncio.Task[None]] = set()
+
+    def __init__(
+        self,
+        address_or_ble_device: BLEDevice,
+        disconnected_callback: Callable[[BleakClient], None] | None,
+        services: Iterable[str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize mock client."""
+        super().__init__(
+            address_or_ble_device, disconnected_callback, services, **kwargs
+        )
+
+    async def _push_frames(self) -> None:
+        """Push frames periodically like the real device, stop when disconnected."""
+        for _ in range(50):  # cap iterations to avoid infinite loops in tests
+            await asyncio.sleep(0)
+            if not self._notify_callback or not self._connected:
+                return
+            self._notify_callback("MockAllpowers", bytearray(self.FRAME))
+            await asyncio.sleep(0.05)
+
+    async def start_notify(
+        self,
+        char_specifier: BleakGATTCharacteristic | int | str | UUID,
+        callback: Callable[
+            [BleakGATTCharacteristic, bytearray], None | Awaitable[None]
+        ],
+        **kwargs: Any,
+    ) -> None:
+        """Subscribe to notifications and start pushing frames."""
+        await super().start_notify(char_specifier, callback, **kwargs)
+        task: asyncio.Task[None] = asyncio.create_task(self._push_frames())
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def disconnect(self) -> None:
+        """Await pending tasks before disconnecting."""
+        if self._tasks:
+            await asyncio.gather(*self._tasks)
+        await super().disconnect()
+
+
+class MockAllpowersChargingClient(MockAllpowersBleakClient):
+    """Mock client that pushes a charging frame."""
+
+    FRAME: bytearray = _FRAME_STATUS_CHARGING
+
+
+class MockAllpowersIdleClient(MockAllpowersBleakClient):
+    """Mock client that pushes an idle frame."""
+
+    FRAME: bytearray = _FRAME_STATUS_IDLE
+
+
+class MockAllpowersSettingsOnlyClient(MockAllpowersBleakClient):
+    """Mock client that first sends a settings frame, then the real status frame.
+
+    Used to verify that settings (short) frames are correctly ignored and the
+    BMS plugin waits for a valid status frame.
+    """
+
+    _sent_settings: bool = False
+
+    async def _push_frames(self) -> None:
+        for _ in range(50):
+            await asyncio.sleep(0)
+            if not self._notify_callback or not self._connected:
+                return
+            if not self._sent_settings:
+                self._notify_callback("MockAllpowers", bytearray(_FRAME_SETTINGS))
+                self._sent_settings = True
+                await asyncio.sleep(0)
+            if self._notify_callback:
+                self._notify_callback(
+                    "MockAllpowers", bytearray(_FRAME_STATUS_DISCHARGING)
+                )
+            await asyncio.sleep(0.05)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_update_discharging(
+    patch_bleak_client: Callable[..., None], keep_alive_fixture: bool
+) -> None:
+    """Test Allpowers BMS data update while discharging."""
+    patch_bleak_client(MockAllpowersBleakClient)
+    bms = BMS(generate_ble_device(), keep_alive_fixture)
+
+    result = await bms.async_update()
+    assert result == _RESULT_DISCHARGING
+
+    # Second call exercises the already-connected path.
+    await bms.async_update()
+    assert bms.is_connected is keep_alive_fixture
+
+    await bms.disconnect()
+
+
+async def test_update_charging(patch_bleak_client: Callable[..., None]) -> None:
+    """Test Allpowers BMS data update while charging (no runtime expected)."""
+    patch_bleak_client(MockAllpowersChargingClient)
+    bms = BMS(generate_ble_device())
+
+    assert await bms.async_update() == _RESULT_CHARGING
+
+    await bms.disconnect()
+
+
+async def test_update_idle(patch_bleak_client: Callable[..., None]) -> None:
+    """Test Allpowers BMS data update while idle (torch on, no outputs, no runtime)."""
+    patch_bleak_client(MockAllpowersIdleClient)
+    bms = BMS(generate_ble_device())
+
+    assert await bms.async_update() == _RESULT_IDLE
+
+    await bms.disconnect()
+
+
+async def test_settings_frame_ignored(
+    patch_bleak_client: Callable[..., None],
+) -> None:
+    """Test that settings (short) frames are silently ignored.
+
+    The mock pushes a settings frame first and then a valid status frame.
+    The BMS plugin should skip the settings frame and successfully parse the
+    status frame.
+    """
+    patch_bleak_client(MockAllpowersSettingsOnlyClient)
+    # Reset class-level state between tests.
+    MockAllpowersSettingsOnlyClient._sent_settings = False
+
+    bms = BMS(generate_ble_device())
+    assert await bms.async_update() == _RESULT_DISCHARGING
+
+    await bms.disconnect()
+
+
+@pytest.mark.parametrize(
+    ("bad_frame", "reason"),
+    [
+        (bytearray(b"\x00" + bytes(14)), "wrong_SOF"),
+        (bytearray(b"\xa5\x65\xb1" + bytes(10)), "too_short"),
+        (bytearray(b""), "empty"),
+    ],
+    ids=["wrong_SOF", "too_short", "empty"],
+)
+async def test_invalid_frame_ignored(
+    monkeypatch: pytest.MonkeyPatch,
+    patch_bleak_client: Callable[..., None],
+    patch_bms_timeout: Callable[..., None],
+    bad_frame: bytearray,
+    reason: str,
+) -> None:
+    """Test that malformed frames are rejected and trigger a timeout."""
+    patch_bms_timeout()
+    monkeypatch.setattr(MockAllpowersBleakClient, "FRAME", bad_frame)
+    patch_bleak_client(MockAllpowersBleakClient)
+
+    bms = BMS(generate_ble_device())
+    with pytest.raises(TimeoutError):
+        await bms.async_update()
+
+    await bms.disconnect()
+
+
+async def test_device_info(patch_bleak_client: Callable[..., None]) -> None:
+    """Test that the BMS returns at minimum default device information."""
+    patch_bleak_client(MockAllpowersBleakClient)
+    bms = BMS(generate_ble_device())
+    info = await bms.device_info()
+    # The standard 0x180A characteristics are mocked by MockBleakClient.
+    assert {"default_manufacturer", "default_model"}.issubset(
+        {**BMS.INFO, **info}
+    )
+    await bms.disconnect()


### PR DESCRIPTION
## Summary

Add support for Allpowers portable power stations (R1500, VOLIX, etc.) as a new `BaseBMS` plugin.

## Protocol

The Allpowers protocol is **push-based** — the device streams status frames over BLE notifications on characteristic `FFF1` (service `FFF0`) without requiring any TX commands.

### Status frame format (≥15 bytes, prefix `0xA5`):
- Byte 7: flags (bit0=DC, bit1=AC, bit2=freq 60Hz, bit4=torch)
- Byte 8: battery level (%)
- Bytes 9-10: input power (W, big-endian)
- Bytes 11-12: output power (W, big-endian)
- Bytes 13-14: minutes remaining (big-endian, `0xFFFF` = charging/idle sentinel)

Short settings frames (~10 bytes) are silently ignored.

## BMSSample keys returned
| Key | Description |
|-----|-------------|
| `battery_level` | SoC % |
| `power` | Net watts (positive=charging, negative=discharging) |
| `runtime` | Seconds remaining (omitted when charging/idle) |
| `chrg_mosfet` | AC output enabled |
| `dischrg_mosfet` | DC output enabled |

## Bluetooth matchers
- `AP S*` (Allpowers branded)
- `VOLIX*` (VOLIX branded)

## Tests
12 tests covering:
- Discharging, charging, idle scenarios
- Settings frame rejection
- Invalid frame handling (wrong SOF, too short, empty)
- Device info
- BMSBasicTests conformance (bms_id, matcher_dict, result_value_types)

## Context
This ports the read-only monitoring from [hacs-allpowers](https://github.com/eXist-FraGGer/hacs-allpowers) into the aiobmsble plugin architecture. The companion hacs-allpowers integration retains write-only control features (switches/selects) that are outside aiobmsble's read-only scope.