### PR TITLE
Add 123SmartBMS support via BLE UART bridge

### DIFF
--- a/aiobmsble/bms/smartbms_bms.py
+++ b/aiobmsble/bms/smartbms_bms.py
@@ -1,0 +1,186 @@
+"""Module to support 123SmartBMS.
+
+Project: aiobmsble, https://pypi.org/p/aiobmsble/
+License: Apache-2.0, http://www.apache.org/licenses/
+"""
+
+import asyncio
+from typing import Final
+
+from bleak.backends.characteristic import BleakGATTCharacteristic
+from bleak.backends.device import BLEDevice
+
+from aiobmsble import BMSConfig, BMSDp, BMSInfo, BMSSample, MatcherPattern, TempSensor
+from aiobmsble.basebms import BaseBMS
+
+
+class BMS(BaseBMS):
+    """123SmartBMS implementation.
+
+    The BMS is accessed via a BLE UART bridge (Nordic UART Service, e.g. the
+    Raytac/Alice nRF52810 module). The BMS pushes one 58 byte status frame
+    per second. Each frame contains the fixed status values plus rotating
+    data: the information of one specific cell and one key/value pair.
+    See docs/smartbms_bms.md for the frame layout and key/value pair
+    definition.
+    """
+
+    INFO: BMSInfo = {
+        "default_manufacturer": "123electric",
+        "default_model": "123SmartBMS",
+    }
+    _MSG_LEN: Final[int] = 58  # frame length in bytes
+    _CELL_OFFSET: Final[int] = 0x0114  # temperature offset, 0x0114 -> 0 degC
+    _KV_POS: Final[int] = 47  # position of the key/value pair key
+    _KV_OFFSET: Final[int] = 25  # key value offset, 25 -> key 0
+    _MAX_KEY: Final[int] = 18  # highest key value
+    _STATUS2_ALARM_MASK: Final[int] = 0x0E  # early warning, Tmin exceed bits
+    _FIELDS: Final[tuple[BMSDp, ...]] = (
+        BMSDp("voltage", 0, 3, False, lambda x: x / 200),
+        BMSDp("battery_level", 40, 1, False),
+        BMSDp("cell_count", 25, 1, False),
+        BMSDp("chrg_mosfet", 30, 1, False, lambda x: bool(x & 0x01)),
+        BMSDp("dischrg_mosfet", 30, 1, False, lambda x: bool(x & 0x02)),
+        BMSDp("problem_code", 30, 1, False, lambda x: (x >> 2) & 0x3F),
+    )
+
+    def __init__(
+        self,
+        ble_device: BLEDevice,
+        config: BMSConfig | None = None,
+        logger_name: str = "",
+    ) -> None:
+        """Initialize private BMS members."""
+        super().__init__(ble_device, config, logger_name)
+        self._msg: bytes = b""
+        self._cells: dict[int, tuple[float, float]] = {}
+        self._kv: dict[int, int] = {}
+
+    @staticmethod
+    def matcher_dict_list() -> list[MatcherPattern]:
+        """Provide BluetoothMatcher definition."""
+        return [
+            {
+                "local_name": pattern,
+                "service_uuid": BMS.uuid_services()[0],
+                "connectable": True,
+            }
+            for pattern in ("123\\SmartBMS", "123BMS-BLE*")
+        ]
+
+    @staticmethod
+    def uuid_services() -> tuple[str, ...]:
+        """Return list of 128-bit UUIDs of services required by BMS."""
+        return ("6e400001-b5a3-f393-e0a9-e50e24dcca9e",)
+
+    @staticmethod
+    def uuid_rx() -> str:
+        """Return 16-bit UUID of characteristic that provides notification/read property."""
+        return "6e400003-b5a3-f393-e0a9-e50e24dcca9e"
+
+    @staticmethod
+    def uuid_tx() -> str:
+        """Return 16-bit UUID of characteristic that provides write property."""
+        return "6e400002-b5a3-f393-e0a9-e50e24dcca9e"
+
+    def _notification_handler(
+        self, _sender: BleakGATTCharacteristic, data: bytearray
+    ) -> None:
+        """Handle the RX characteristics notify event (new data arrives)."""
+        self._log.debug("RX BLE data: %s", data)
+        self._frame.extend(data)
+        frame: Final[bytearray] = self._frame
+        offset: int = 0
+        while len(frame) - offset >= BMS._MSG_LEN:
+            if BMS._valid_frame(bytes(frame[offset : offset + BMS._MSG_LEN])):
+                self._process_frame(bytes(frame[offset : offset + BMS._MSG_LEN]))
+                offset += BMS._MSG_LEN
+            else:
+                offset += 1  # no header, resync on next possible frame start
+        del frame[:offset]
+
+    @staticmethod
+    def _valid_frame(frame: bytes) -> bool:
+        """Check the 8-bit checksum at the end of the frame."""
+        return sum(frame[: BMS._MSG_LEN - 1]) & 0xFF == frame[BMS._MSG_LEN - 1]
+
+    def _process_frame(self, frame: bytes) -> None:
+        """Process a valid frame and accumulate rotating data."""
+        self._msg = frame
+        cell_nr: Final[int] = frame[24]
+        cell_count: Final[int] = frame[25]
+        if 0 < cell_nr <= cell_count:
+            self._cells[cell_nr] = (
+                int.from_bytes(frame[26:28], "big") / 200,
+                BMS._decode_temperature(frame[28:30]),
+            )
+        key: Final[int] = frame[BMS._KV_POS] - BMS._KV_OFFSET
+        if 0 <= key <= BMS._MAX_KEY:
+            self._kv[key] = frame[BMS._KV_POS + 1]
+        self._msg_event.set()
+
+    @staticmethod
+    def _decode_current(raw: int) -> float:
+        """Decode the sum current from sign byte and value with 0.125 A resolution."""
+        sign: Final[int] = (raw >> 16) & 0xFF
+        value: Final[float] = (raw & 0xFFFF) * 0.125
+        if sign == ord("X"):
+            return 0.0
+        return -value if sign == ord("-") else value
+
+    @staticmethod
+    def _decode_temperature(raw: bytes) -> float:
+        """Decode a temperature value with 1 degC resolution."""
+        return int.from_bytes(raw, "big") - BMS._CELL_OFFSET
+
+    async def _async_update(self) -> BMSSample:
+        """Update battery status information."""
+        await asyncio.wait_for(self._wait_event(), timeout=BMS.TIMEOUT)
+
+        result: BMSSample = BMS._decode_data(BMS._FIELDS, self._msg, byteorder="big")
+        result["current"] = BMS._decode_current(int.from_bytes(self._msg[9:12], "big"))
+
+        vmin: Final[float] = int.from_bytes(self._msg[12:14], "big") / 200
+        vmax: Final[float] = int.from_bytes(self._msg[15:17], "big") / 200
+        result["delta_voltage"] = round(vmax - vmin, 3)
+
+        temp_values: list[TempSensor] = [
+            TempSensor(
+                BMS._decode_temperature(self._msg[18:20]), TempSensor.T.CELL_MIN
+            ),
+            TempSensor(
+                BMS._decode_temperature(self._msg[21:23]), TempSensor.T.CELL_MAX
+            ),
+        ]
+
+        cell_count: Final[int] = result["cell_count"]
+        cells: list[int] = [nr for nr in range(1, cell_count + 1) if nr in self._cells]
+        if len(cells) == cell_count:
+            # only report cells once the full set has been received (rotating data)
+            result["cell_voltages"] = [self._cells[nr][0] for nr in cells]
+            temp_values.extend(
+                TempSensor(self._cells[nr][1], TempSensor.T.CELL) for nr in cells
+            )
+        result["temp_values"] = temp_values
+
+        if 0 in self._kv and self._kv[0] <= 100:
+            result["battery_health"] = self._kv[0]
+        if 8 in self._kv and 9 in self._kv:
+            result["cycles"] = (self._kv[8] << 8) + self._kv[9]
+        if 16 in self._kv:
+            result["problem_code"] = result.get("problem_code", 0) | (
+                self._kv[16] & BMS._STATUS2_ALARM_MASK
+            )
+        if 4 in self._kv and 5 in self._kv and cell_count:
+            nominal: Final[float] = (
+                (self._kv[4] << 8) + self._kv[5]
+            ) / 200  # nominal cell voltage
+            capacity_kwh: Final[float] = int.from_bytes(self._msg[49:51], "big") / 10
+            if nominal > 0:
+                result["design_capacity"] = round(
+                    capacity_kwh * 1000 / (nominal * cell_count)
+                )
+
+        result["cycle_capacity"] = int.from_bytes(self._msg[34:37], "big")
+
+        return result

--- a/aiobmsble/test_data/smartbms_bms.json
+++ b/aiobmsble/test_data/smartbms_bms.json
@@ -1,0 +1,21 @@
+[
+  {
+    "advertisement": {
+      "local_name": "123\\SmartBMS",
+      "platform_data": ["E8:A2:C9:23:72:94"],
+      "rssi": -91,
+      "manufacturer_data": { "2330": "00060d02" },
+      "service_uuids": [
+        "6e400001-b5a3-f393-e0a9-e50e24dcca9e"
+      ]
+    },
+    "type": "smartbms_bms",
+    "_comments": [
+      "source https://github.com/patman15/BMS_BLE-HA/issues/542",
+      "123SmartBMS gen3 via Nordic UART bridge (nRF52810 UART AT Command)",
+      "RX 6e400002 (write-without-response, write, max 244 B), TX 6e400003 (notify)",
+      "also advertises Battery Service 180f, Tx Power 1804, Device Info 180a",
+      "manufacturer string: nRF52810 UART AT Command"
+    ]
+  }
+]

--- a/docs/smartbms_bms.md
+++ b/docs/smartbms_bms.md
@@ -1,0 +1,112 @@
+# 123SmartBMS
+
+Protocol details based on the official UART protocol documentation (v3.3.11) and a
+BLE advertisement capture of a gen3 battery.
+
+## Device Discovery
+
+The BMS is not directly BLE-addressable; it is accessed via a BLE UART bridge
+(Nordic UART Service, e.g. the Raytac/Alice nRF52810 module, advertising string
+`nRF52810 UART AT Command`).
+
+| Attribute | Value |
+|-----------|-------|
+| Local name | `123\SmartBMS` (also `123BMS-BLE*` after rename) |
+| Service UUID | `6e400001-b5a3-f393-e0a9-e50e24dcca9e` |
+| RX (notify) | `6e400003-b5a3-f393-e0a9-e50e24dcca9e` |
+| TX (write) | `6e400002-b5a3-f393-e0a9-e50e24dcca9e` |
+| Manufacturer data | `0x2330: 0x060d02` (gen3 capture) |
+
+The bridge additionally advertises Battery Service (`180f`), Tx Power (`1804`/`2a07`)
+and Device Information (`180a`).
+
+## Protocol
+
+The BMS pushes one 58 byte status frame per second, big-endian. The last byte is
+the 8-bit checksum: `frame[57] = sum(frame[:57]) & 0xFF`. There is no frame
+header; the driver resynchronizes on any byte position until the checksum matches.
+
+## Frame Format
+
+| Offset | Size | Field | Description |
+|--------|------|-------|-------------|
+| 0 | 3 | battery voltage | Pack voltage, 5 mV/bit |
+| 3 | 1+2 | charge current | ASCII sign byte (`+`/`-`/`X`) + magnitude, 125 mA/bit |
+| 6 | 1+2 | discharge current | ASCII sign byte + magnitude, 125 mA/bit |
+| 9 | 1+2 | total current | ASCII sign byte + magnitude, 125 mA/bit |
+| 12 | 2 | V-min | Minimum cell voltage, 5 mV/bit |
+| 14 | 1 | V-min cell number | 1-based cell index |
+| 15 | 2 | V-max | Maximum cell voltage, 5 mV/bit |
+| 17 | 1 | V-max cell number | 1-based cell index |
+| 18 | 2 | T-min | Minimum cell temperature, 1 °C/bit, offset `0x0114` |
+| 20 | 1 | T-min cell number | 1-based cell index |
+| 21 | 2 | T-max | Maximum cell temperature, 1 °C/bit, offset `0x0114` |
+| 23 | 1 | T-max cell number | 1-based cell index |
+| 24 | 1 | cell number | Number of the cell whose data is transferred (rotating) |
+| 25 | 1 | cell count | Total number of cells |
+| 26 | 2 | cell voltage | Voltage of the cell from offset 24, 5 mV/bit |
+| 28 | 2 | cell temperature | Temperature of the cell from offset 24, offset `0x0114` |
+| 30 | 1 | status byte 1 | See below |
+| 34 | 3 | stored energy | Energy stored in Wh |
+| 40 | 1 | SoC | State of charge in % |
+| 47 | 2 | key/value pair | Rotating data, see below |
+| 49 | 2 | capacity | Battery capacity, 0.1 kWh/bit |
+| 51 | 6 | settings | V-balance/min/max settings (not parsed) |
+| 57 | 1 | checksum | `sum(frame[:57]) & 0xFF` |
+
+### Status byte 1 (offset 30)
+
+| Bit | Meaning |
+|-----|---------|
+| 0 | Charge FET allowed (chrg_mosfet) |
+| 1 | Discharge FET allowed (dischrg_mosfet) |
+| 2 | Communication error |
+| 3–6 | Voltage/temperature exceeded (problem_code, bits 0–3) |
+| 7 | SoC not calibrated |
+
+### Rotating cell data
+
+The specific cell information (offsets 24–29) rotates through all cells, one per
+frame. The driver collects `(voltage, temperature)` per cell number and only
+reports `cell_voltages` / per-cell temperatures once the complete set has been
+received.
+
+### Key/value pairs (offset 47: key, offset 48: value)
+
+The key is stored with an offset of 25 (raw key 25 = key 0). One pair is
+transmitted per frame, rotating, so the full cycle takes roughly 20 s.
+
+| Key | Bytes | Field |
+|-----|-------|-------|
+| 0 | 1 | SoH in % |
+| 1 | 1 | Charge efficiency |
+| 2–3 | 2 | V-low setting |
+| 4–5 | 2 | Nominal cell voltage, 5 mV/bit |
+| 6–7 | 2 | Firmware version (nibbles) |
+| 8–9 | 2 | Charge cycles |
+| 10–12 | 3 | Charged energy in Wh |
+| 13–15 | 3 | Discharged energy in Wh |
+| 16 | 1 | Status byte 2 (see below) |
+| 17–18 | 2 | V-full setting |
+
+### Status byte 2 (key 16)
+
+| Bit | Meaning |
+|-----|---------|
+| 1 | Early warning |
+| 2 | T-min discharge exceeded |
+| 3 | T-min charge exceeded |
+| 4 | Relay charge |
+| 5 | Relay load |
+
+Bits 1–3 are ORed into `problem_code` (`0x0E` mask).
+
+## Notes
+
+- Temperature decode follows the official documentation: `°C = raw - 0x0114`
+  (`0x0114` = 0 °C, `0x0128` = 20 °C). The Victron Venus driver uses a different
+  scaling (`round(raw * 0.857 - 232)`); this still needs live validation.
+- `design_capacity` is derived from the configured capacity and nominal cell
+  voltage: `capacity_kWh * 1000 / (nominal_V * cell_count)`.
+- `cycle_capacity` is taken from the stored energy field (Wh).
+- SoC byte interpretation (plain vs. /2) still needs live validation.

--- a/tests/bms/test_smartbms_bms.py
+++ b/tests/bms/test_smartbms_bms.py
@@ -1,0 +1,356 @@
+"""Test the 123SmartBMS implementation."""
+
+from bleak.backends.characteristic import BleakGATTCharacteristic
+from bleak.backends.service import BleakGATTService
+import pytest
+
+from aiobmsble import BMSConfig, BMSSample, TempSensor as TS
+from aiobmsble.bms.smartbms_bms import BMS
+from tests.bluetooth import generate_ble_device
+from tests.conftest import MockBleakClient
+from tests.test_basebms import BMSBasicTests, verify_device_info
+
+_NOTIFY_CHAR: BleakGATTCharacteristic = BleakGATTCharacteristic(
+    None,
+    1,
+    BMS.uuid_rx(),
+    ["notify"],
+    lambda: 512,
+    BleakGATTService(None, 0, BMS.uuid_services()[0]),
+)
+
+
+def _frame(
+    *,
+    cell_nr: int = 0,
+    cell_count: int = 16,
+    cell_v: int = 0x0272,
+    cell_t: int = 0x0128,
+    key: int = 0,
+    kv: int = 0,
+    current_sign: int = ord("+"),
+    current: int = 0x0040,
+    status: int = 0x03,
+    soc: int = 75,
+    energy: int = 0x0FA0,
+    capacity: int = 0x00A0,
+) -> bytes:
+    """Build a valid 58 byte status frame, checksum appended."""
+    frame: bytearray = bytearray(58)
+    frame[0:3] = (0x0105FF).to_bytes(3, "big")  # battery voltage 335.355 V
+    frame[3] = ord("+")  # charge current sign
+    frame[4:6] = (0x0000).to_bytes(2, "big")  # charge current
+    frame[6] = ord("X")  # discharge current sign (unknown)
+    frame[7:9] = (0x0000).to_bytes(2, "big")  # discharge current
+    frame[9] = current_sign  # total current sign
+    frame[10:12] = current.to_bytes(2, "big")  # total current (8.0 A)
+    frame[12:14] = (0x0272).to_bytes(2, "big")  # min cell voltage 3.13 V
+    frame[14] = 1  # min cell number
+    frame[15:17] = (0x0280).to_bytes(2, "big")  # max cell voltage 3.2 V
+    frame[17] = cell_count  # max cell number
+    frame[18:20] = (0x0128).to_bytes(2, "big")  # min cell temp 20 degC
+    frame[20] = 1  # min temp cell number
+    frame[21:23] = (0x0128).to_bytes(2, "big")  # max cell temp 20 degC
+    frame[23] = cell_count  # max temp cell number
+    frame[24] = cell_nr  # number of cell whose data is transferred
+    frame[25] = cell_count  # cell count
+    frame[26:28] = cell_v.to_bytes(2, "big")  # specific cell voltage
+    frame[28:30] = cell_t.to_bytes(2, "big")  # specific cell temperature
+    frame[30] = status  # status byte 1
+    frame[34:37] = energy.to_bytes(3, "big")  # stored energy in Wh
+    frame[40] = soc  # SoC in %
+    frame[47] = key + 25  # key/value pair key
+    frame[48] = kv  # key/value pair value
+    frame[49:51] = capacity.to_bytes(2, "big")  # capacity in 0.1 kWh
+    frame[51:57] = b"\x00\x00\x00\x00\x00\x00"  # V-min/max/balance settings
+    frame[57] = sum(frame[:57]) & 0xFF  # checksum
+    return bytes(frame)
+
+
+def _stream() -> bytes:
+    """Build a notification stream with all cells and key/value pairs."""
+    frames: list[bytes] = [
+        _frame(cell_nr=nr, cell_v=0x0270 + nr - 1) for nr in range(1, 17)
+    ]
+    frames += [
+        _frame(key=0, kv=98),  # SoH
+        _frame(key=4, kv=0x02),  # nominal cell voltage high byte
+        _frame(key=5, kv=0x80),  # nominal cell voltage low byte (3.2 V)
+        _frame(key=8, kv=0x04),  # charge cycles high byte
+        _frame(key=9, kv=0xD2),  # charge cycles low byte (1234)
+        _frame(key=16, kv=0x00),  # status byte 2 (no alarms)
+    ]
+    return b"".join(frames)
+
+
+_RESULT_DEFS: BMSSample = {
+    "voltage": 335.355,
+    "current": 8.0,
+    "battery_level": 75,
+    "cell_count": 16,
+    "chrg_mosfet": True,
+    "dischrg_mosfet": True,
+    "problem_code": 0,
+    "delta_voltage": 0.07,
+    "temp_values": [TS(20, TS.T.CELL_MIN), TS(20, TS.T.CELL_MAX)]
+    + [TS(20, TS.T.CELL) for _ in range(16)],
+    "cell_voltages": [(0x0270 + nr - 1) / 200 for nr in range(1, 17)],
+    "battery_health": 98,
+    "cycles": 1234,
+    "design_capacity": 312,
+    "cycle_capacity": 4000,
+    "battery_charging": True,
+    "power": 2682.84,
+    "cycle_charge": 234.0,
+    "temperature": 20.0,
+    "problem": False,
+}
+
+
+class TestBasicBMS(BMSBasicTests):
+    """Test the basic BMS functionality."""
+
+    bms_class = BMS
+
+
+class MockSmartBMSBleakClient(MockBleakClient):
+    """Emulate a 123SmartBMS BLE UART bridge BleakClient."""
+
+    STREAM: bytes = _stream()
+
+    async def start_notify(self, char_specifier, callback, **kwargs) -> None:
+        """Mock start_notify."""
+        await super().start_notify(char_specifier, callback, **kwargs)
+        assert self._notify_callback is not None
+        if self.STREAM:
+            self._notify_callback("MockSmartBMSBleakClient", bytearray(self.STREAM))
+
+
+async def test_update(patch_bleak_client, keep_alive_fixture: bool) -> None:
+    """Test 123SmartBMS data update."""
+
+    patch_bleak_client(MockSmartBMSBleakClient)
+
+    bms = BMS(generate_ble_device(), BMSConfig(keep_alive_fixture))
+
+    assert await bms.async_update() == _RESULT_DEFS
+
+    # query again to check already connected state
+    if keep_alive_fixture:
+        bms._notification_handler(
+            _NOTIFY_CHAR, bytearray(MockSmartBMSBleakClient.STREAM)
+        )
+    assert await bms.async_update() == _RESULT_DEFS
+    assert bms.is_connected is keep_alive_fixture
+
+    await bms.disconnect()
+
+
+async def test_partial_update(monkeypatch, patch_bleak_client) -> None:
+    """Test data update if not all cells have been received yet."""
+
+    partial: bytes = b"".join(
+        _frame(cell_nr=nr, cell_v=0x0270 + nr - 1, key=99, kv=0) for nr in (1, 2, 3)
+    ) + _frame(key=99, kv=0)
+    monkeypatch.setattr(MockSmartBMSBleakClient, "STREAM", partial)
+    patch_bleak_client(MockSmartBMSBleakClient)
+
+    bms = BMS(generate_ble_device())
+
+    result: BMSSample = await bms.async_update()
+    assert "cell_voltages" not in result
+    assert "battery_health" not in result
+    assert "cycles" not in result
+    assert "design_capacity" not in result
+    assert result["temperature"] == 20.0
+    assert result["cycle_capacity"] == 4000
+
+    await bms.disconnect()
+
+
+async def test_fragmented_stream(monkeypatch, patch_bleak_client) -> None:
+    """Test data update with the stream split into chunks across notifications."""
+
+    monkeypatch.setattr(MockSmartBMSBleakClient, "STREAM", b"")
+    patch_bleak_client(MockSmartBMSBleakClient)
+
+    bms = BMS(generate_ble_device())
+    await bms._connect()
+
+    stream: bytes = _stream()
+    for i in range(0, len(stream), 70):  # odd chunk size, frames split mid-way
+        bms._notification_handler(_NOTIFY_CHAR, bytearray(stream[i : i + 70]))
+
+    assert await bms.async_update() == _RESULT_DEFS
+    await bms.disconnect()
+
+
+@pytest.mark.parametrize(
+    ("current_sign", "expected_current", "expected_power", "expected_charging"),
+    [
+        (ord("-"), -8.0, -2682.84, False),
+        (ord("X"), 0.0, 0.0, False),
+    ],
+    ids=["discharge", "unknown"],
+)
+async def test_current_signs(
+    monkeypatch,
+    patch_bleak_client,
+    current_sign: int,
+    expected_current: float,
+    expected_power: float,
+    expected_charging: bool,
+) -> None:
+    """Test current decoding with discharge and unknown sign."""
+
+    monkeypatch.setattr(
+        MockSmartBMSBleakClient, "STREAM", _frame(current_sign=current_sign)
+    )
+    patch_bleak_client(MockSmartBMSBleakClient)
+
+    bms = BMS(generate_ble_device())
+
+    result: BMSSample = await bms.async_update()
+    assert result["current"] == expected_current
+    assert result["battery_charging"] is expected_charging
+    assert result["power"] == expected_power
+
+    await bms.disconnect()
+
+
+@pytest.mark.parametrize(
+    ("status", "status2", "expected"),
+    [
+        (0x03, 0x00, 0x00),
+        (0x2C, 0x00, 0x0B),
+        (0x03, 0x0E, 0x0E),
+        (0x2C, 0x0A, 0x0B),
+    ],
+    ids=["ok", "status1_alarm", "status2_alarm", "both_alarm"],
+)
+async def test_problem_response(
+    monkeypatch,
+    patch_bleak_client,
+    status: int,
+    status2: int,
+    expected: int,
+) -> None:
+    """Test data update with BMS returning error flags."""
+
+    monkeypatch.setattr(
+        MockSmartBMSBleakClient,
+        "STREAM",
+        _frame(status=status, key=16, kv=status2),
+    )
+    patch_bleak_client(MockSmartBMSBleakClient)
+
+    bms = BMS(generate_ble_device())
+
+    result: BMSSample = await bms.async_update()
+    assert result["problem_code"] == expected
+    assert result["problem"] is (expected != 0)
+
+    await bms.disconnect()
+
+
+async def test_battery_health_guard(monkeypatch, patch_bleak_client) -> None:
+    """Test that out-of-range SoH is ignored."""
+
+    stream: bytes = b"".join(
+        [_frame(key=4, kv=0x02), _frame(key=5, kv=0x80), _frame(key=0, kv=101)]
+    )
+    monkeypatch.setattr(MockSmartBMSBleakClient, "STREAM", stream)
+    patch_bleak_client(MockSmartBMSBleakClient)
+
+    bms = BMS(generate_ble_device())
+
+    result: BMSSample = await bms.async_update()
+    assert "battery_health" not in result
+    assert result["design_capacity"] == 312
+
+    await bms.disconnect()
+
+
+async def test_zero_nominal_voltage(monkeypatch, patch_bleak_client) -> None:
+    """Test that design capacity is skipped if the nominal voltage is zero."""
+
+    stream: bytes = b"".join(
+        [_frame(key=0, kv=98), _frame(key=4, kv=0x00), _frame(key=5, kv=0x00)]
+    )
+    monkeypatch.setattr(MockSmartBMSBleakClient, "STREAM", stream)
+    patch_bleak_client(MockSmartBMSBleakClient)
+
+    bms = BMS(generate_ble_device())
+
+    result: BMSSample = await bms.async_update()
+    assert result["battery_health"] == 98
+    assert "design_capacity" not in result
+
+    await bms.disconnect()
+
+
+@pytest.mark.parametrize(
+    ("cell_nr", "id_"),
+    [(0, "zero"), (17, "too_high")],
+    ids=["zero", "too_high"],
+)
+async def test_out_of_range_cell(
+    monkeypatch, patch_bleak_client, cell_nr: int, id_: str
+) -> None:
+    """Test that out-of-range cell info is ignored."""
+
+    monkeypatch.setattr(
+        MockSmartBMSBleakClient,
+        "STREAM",
+        _frame(cell_nr=cell_nr, key=99, kv=0),
+    )
+    patch_bleak_client(MockSmartBMSBleakClient)
+
+    bms = BMS(generate_ble_device())
+
+    result: BMSSample = await bms.async_update()
+    assert "cell_voltages" not in result
+    assert "battery_health" not in result
+
+    await bms.disconnect()
+
+
+@pytest.mark.parametrize(
+    ("invalid_stream"),
+    [
+        b"",
+        _frame()[:40],
+        bytes(_frame()[:-1]) + b"\x00",
+    ],
+    ids=["empty", "truncated", "wrong_checksum"],
+)
+async def test_invalid_frame(
+    monkeypatch,
+    patch_bleak_client,
+    patch_bms_timeout,
+    invalid_stream: bytes,
+) -> None:
+    """Test data update with the BMS returning invalid data."""
+
+    patch_bms_timeout("smartbms_bms")
+    monkeypatch.setattr(MockSmartBMSBleakClient, "STREAM", invalid_stream)
+    patch_bleak_client(MockSmartBMSBleakClient)
+
+    bms = BMS(generate_ble_device())
+
+    result: BMSSample = {}
+    with pytest.raises(TimeoutError):
+        result = await bms.async_update()
+
+    assert not result
+    await bms.disconnect()
+
+
+async def test_device_info(patch_bleak_client) -> None:
+    """Test that the BMS returns initialized dynamic device information."""
+    await verify_device_info(patch_bleak_client, MockSmartBMSBleakClient, BMS)
+
+
+def test_uuid_tx() -> None:
+    """Test that the TX UUID of the Nordic UART service is returned."""
+    assert BMS.uuid_tx() == "6e400002-b5a3-f393-e0a9-e50e24dcca9e"


### PR DESCRIPTION
## Checklist

### [Code Requirements][coding-guide]
- [x] There is no commented out code in this PR.
- [x] The code has been formatted according to Ruff. (`ruff check .`)
- [x] The code passes code quality checks of mypy. (`mypy .`)
- [x] The code passes spelling checks of codespell. (`codespell .`)

### [Architecture][architecture-guide] for new BMS types
- [x] The `BMSSample` structure is being filled with all available BMS data.
- [x] BMS frames are checked for validity, e.g. CRC, length, allowed type.
- [x] A recorded BLE advertisement has been added for testing.
- [x] The code does not require persistent values.

### Testing
- [x] Local tests pass and coverage is 100% branch.
- [x] Tests have been added to verify that the new code works.
- [x] Tests use recorded data from the BMS, i.e. test data shall not be generated.

### Contributing
- [ ] Especially, for new BMSs, feel free to add your nickname to the `authors` list in `pyproject.toml`
- [x] I agree that the [project license][LICENSE] is used for my contribution

[contribution-guide]: https://github.com/patman15/aiobmsble/tree/main?tab=contributing-ov-file
[coding-guide]: https://github.com/patman15/aiobmsble/tree/main?tab=contributing-ov-file#coding-style-guidelines
[architecture-guide]: https://github.com/patman15/aiobmsble/tree/main?tab=contributing-ov-file#architecture-guidelines
[BMS-type]: https://github.com/patman15/aiobmsble/tree/main?tab=contributing-ov-file#how-to-qualify-as-a-bms
[LICENSE]: https://github.com/patman15/aiobmsble/blob/main/LICENSE

## Summary

Add support for the 123SmartBMS, a LiFePO4 battery BMS that is accessed over
Bluetooth through a Nordic UART Service bridge (e.g. Raytac/Alice nRF52810,
advertising as `nRF52810 UART AT Command`).

The BMS pushes one 58 byte big-endian status frame per second (8-bit checksum
in the last byte). Each frame contains the fixed status values plus rotating
data: the `(voltage, temperature)` of one specific cell and one key/value pair.
The driver accumulates the rotating data and only emits cell/health values once
the complete set has been received. See `docs/smartbms_bms.md` for the full
frame layout, status bytes and key/value pair definition.

### Notes

- Advertisement recorded from a gen3 device (see
  https://github.com/patman15/BMS_BLE-HA/issues/542), local name `123\SmartBMS`,
  service UUID `6e400001-b5a3-f393-e0a9-e50e24dcca9e`.
- The matcher additionally accepts `123BMS-BLE*` for devices renamed via the
  mobile app (pending live confirmation).
- Temperature decode follows the official UART protocol documentation
  (`raw - 0x0114`); a live-device sanity check is still pending.
