### PR TITLE
Add support for C4S100-family generic Modbus-over-BLE Smart BMS

### DIFF
--- a/aiobmsble/bms/c4s_bms.py
+++ b/aiobmsble/bms/c4s_bms.py
@@ -1,0 +1,145 @@
+"""Module to support "C4S100"-family generic Modbus-over-BLE Smart BMS.
+
+Reverse-engineered from a 4S/100A LiFePO4 BMS sold under the local BLE name
+"C4S100IEnnnnn" (app: "E-BMS"), HW module RC6621A (Onmicro HS6621CM,
+transparent BLE-UART bridge). The application-level protocol is plain
+MODBUS RTU (slave id 0x02, function 0x03 - Read Holding Registers) carried
+transparently inside the Nordic UART Service. A single request for the 70
+holding registers starting at address 0x0000 returns the complete telemetry
+set (voltage, signed current, SOC, cell voltages, capacity, cycles, temps).
+
+Project: aiobmsble, https://pypi.org/p/aiobmsble/
+License: Apache-2.0, http://www.apache.org/licenses/
+"""
+
+from typing import Final
+
+from bleak.backends.characteristic import BleakGATTCharacteristic
+from bleak.backends.device import BLEDevice
+
+from aiobmsble import BMSConfig, BMSDp, BMSInfo, BMSSample, MatcherPattern, TempSensor
+from aiobmsble.basebms import BaseBMS, crc_modbus
+
+
+class BMS(BaseBMS):
+    """C4S100-family generic Modbus-over-BLE Smart BMS implementation."""
+
+    INFO: BMSInfo = {
+        "default_manufacturer": "Generic",
+        "default_model": "C4S100 Smart BMS (RC6621A)",
+    }
+    _HEAD: Final[bytes] = b"\x02\x03"  # slave id 0x02, function 0x03 (read holding regs)
+    _FRAME_LEN: Final[int] = 5  # head(2) + byte-count(1) + CRC(2)
+    _CELLS: Final[int] = 4  # fixed 4S pack
+    _TEMPS: Final[int] = 2  # 2 physical temp sensors (MOS_T, ENV_T); app mirrors
+    #  them a second time as TCell1/TCell2 with identical values, not reported here
+    _REG_COUNT: Final[int] = 0x46  # 70 holding registers polled in one request
+    _RESP_LEN: Final[int] = _REG_COUNT * 2  # expected byte-count field (0x8C)
+
+    # BMSDp(key, pos, size, signed, fct, idx)
+    # pos = byte offset within the full received frame (0=addr,1=func,2=byte-count,
+    # 3.. = register data, big-endian, 2 bytes/register)
+    _FIELDS: Final[tuple[BMSDp, ...]] = (
+        BMSDp("voltage", 3, 2, False, lambda x: x / 100, _RESP_LEN),  # reg0
+        # reg1 (hi word) + reg2 (lo word): signed 32-bit current, 0.01A,
+        # positive = charging, negative = discharging (matches app & library convention)
+        BMSDp("current", 5, 4, True, lambda x: x / 100, _RESP_LEN),  # reg1+reg2
+        BMSDp("battery_level", 9, 2, False, idx=_RESP_LEN),  # reg3, SOC %
+        BMSDp("cycle_charge", 11, 2, False, lambda x: x / 100, _RESP_LEN),  # reg4, Ah
+        BMSDp(
+            "design_capacity", 13, 2, False, lambda x: round(x / 100), _RESP_LEN
+        ),  # reg5, Ah
+        BMSDp("cycles", 15, 2, False, idx=_RESP_LEN),  # reg6
+        BMSDp("battery_health", 17, 2, False, idx=_RESP_LEN),  # reg7, SOH %
+        BMSDp("delta_voltage", 29, 2, False, lambda x: x / 1000, _RESP_LEN),  # reg13
+        BMSDp("cell_count", 45, 2, False, idx=_RESP_LEN),  # reg21
+    )
+    _RESPS: Final = frozenset(field.idx for field in _FIELDS)
+    _CMDS: Final[frozenset[tuple[int, int]]] = frozenset({(0x0, _REG_COUNT)})
+
+    def __init__(
+        self,
+        ble_device: BLEDevice,
+        config: BMSConfig | None = None,
+        logger_name: str = "",
+    ) -> None:
+        """Initialize private BMS members."""
+        super().__init__(ble_device, config, logger_name)
+        self._msg: dict[int, bytes] = {}
+
+    @staticmethod
+    def matcher_dict_list() -> list[MatcherPattern]:
+        """Provide BluetoothMatcher definition."""
+        return [
+            {  # observed name: "C4S100IE06007" (model prefix + serial, Unix glob)
+                "local_name": "C4S100IE?????",
+                "service_uuid": BMS.uuid_services()[0],
+                "connectable": True,
+            }
+        ]
+
+    @staticmethod
+    def uuid_services() -> tuple[str, ...]:
+        """Return list of 128-bit UUIDs of services required by BMS."""
+        return ("6e400001-b5a3-f393-e0a9-e50e24dcca9e",)
+
+    @staticmethod
+    def uuid_rx() -> str:
+        """Return 16-bit UUID of characteristic that provides notification/read property."""
+        return "6e400003-b5a3-f393-e0a9-e50e24dcca9e"
+
+    @staticmethod
+    def uuid_tx() -> str:
+        """Return 16-bit UUID of characteristic that provides write property."""
+        return "6e400002-b5a3-f393-e0a9-e50e24dcca9e"
+
+    def _notification_handler(
+        self, _sender: BleakGATTCharacteristic, data: bytearray
+    ) -> None:
+        """Handle the RX characteristics notify event (new data arrives)."""
+        self._log.debug("RX BLE data: %s", data)
+
+        if not data.startswith(BMS._HEAD):
+            self._log.debug("incorrect SOF")
+            return
+
+        if len(data) < BMS._FRAME_LEN or len(data) != data[2] + BMS._FRAME_LEN:
+            self._log.debug("incorrect frame length")
+            return
+
+        if not self._check_integrity(
+            data,
+            crc_modbus,
+            slice(None, -2),
+            slice(-2, None),
+            "little",
+        ):
+            return
+
+        self._msg[data[2]] = bytes(data)
+        self._msg_event.set()
+
+    async def _async_update(self) -> BMSSample:
+        """Update battery status information."""
+        self._msg.clear()
+        for addr, length in BMS._CMDS:
+            await self._await_msg(BMS._cmd_modbus(dev_id=0x2, addr=addr, count=length))
+        if not BMS._RESPS.issubset(set(self._msg.keys())):
+            self._log.debug("incomplete data set %s", self._msg.keys())
+            raise TimeoutError("BMS data incomplete.")
+
+        result: BMSSample = BMS._decode_data(BMS._FIELDS, self._msg)
+        result["cell_voltages"] = BMS._cell_voltages(
+            self._msg[BMS._RESP_LEN],
+            cells=result.get("cell_count", BMS._CELLS),
+            start=47,  # reg22
+        )
+        result["temp_sensors"] = BMS._TEMPS
+        result["temp_values"] = BMS._temp_values(
+            self._msg[BMS._RESP_LEN],
+            start=35,  # reg16 (MOS_T), reg17 (ENV_T)
+            values=BMS._TEMPS,
+            types=(TempSensor.T.MOSFET, TempSensor.T.AMBIENT),
+        )
+
+        return result

--- a/aiobmsble/bms/c4s_bms.py
+++ b/aiobmsble/bms/c4s_bms.py
@@ -11,43 +11,33 @@ from aiobmsble.bms.vatrer_bms import BMS as VatrerBMS
 
 
 class BMS(VatrerBMS):
-    """C4S100-family generic Modbus-over-BLE Smart BMS (derived from VatrerBMS).
-
-    Inherits the transport layer unchanged from VatrerBMS: uuid_services(),
-    uuid_rx(), uuid_tx(), _notification_handler(), _HEAD, _FRAME_LEN, and
-    __init__ are all identical between the two devices. See
-    docs/c4s_bms.md for the full protocol writeup.
-    """
+    """C4S100-family generic Modbus-over-BLE Smart BMS (derived from VatrerBMS)."""
 
     INFO: BMSInfo = {
         "default_manufacturer": "Generic",
         "default_model": "C4S100 Smart BMS (RC6621A)",
     }
-    _CELLS: Final[int] = 4  # fixed 4S pack
     _TEMPS: Final[int] = 2  # 2 physical temp sensors (MOS_T, ENV_T), see docs
     _REG_COUNT: Final[int] = 0x46  # 70 holding registers polled in one request
-    _RESP_LEN: Final[int] = _REG_COUNT * 2  # expected byte-count field (0x8C)
 
     # BMSDp(key, pos, size, signed, fct, idx); pos/idx documented in docs/c4s_bms.md
     _FIELDS: tuple[BMSDp, ...] = (
-        BMSDp("voltage", 3, 2, False, lambda x: x / 100, _RESP_LEN),
-        BMSDp("current", 5, 4, True, lambda x: x / 100, _RESP_LEN),
-        BMSDp("battery_level", 9, 2, False, idx=_RESP_LEN),
-        BMSDp("cycle_charge", 11, 2, False, lambda x: x / 100, _RESP_LEN),
-        BMSDp(
-            "design_capacity", 13, 2, False, lambda x: round(x / 100), _RESP_LEN
-        ),
-        BMSDp("cycles", 15, 2, False, idx=_RESP_LEN),
-        BMSDp("battery_health", 17, 2, False, idx=_RESP_LEN),
-        BMSDp("delta_voltage", 29, 2, False, lambda x: x / 1000, _RESP_LEN),
-        BMSDp("cell_count", 45, 2, False, idx=_RESP_LEN),
+        BMSDp("voltage", 3, 2, False, lambda x: x / 100),
+        BMSDp("current", 5, 4, True, lambda x: x / 100),
+        BMSDp("battery_level", 9, 2, False),
+        BMSDp("cycle_charge", 11, 2, False, lambda x: x / 100),
+        BMSDp("design_capacity", 13, 2, False, lambda x: round(x / 100)),
+        BMSDp("cycles", 15, 2, False),
+        BMSDp("battery_health", 17, 2, False),
+        BMSDp("delta_voltage", 29, 2, False, lambda x: x / 1000),
+        BMSDp("cell_count", 45, 2, False),
     )
 
     @staticmethod
     def matcher_dict_list() -> list[MatcherPattern]:
         """Provide BluetoothMatcher definition."""
         return [
-            {  # observed name: "C4S100IE06007" (model prefix + serial, Unix glob)
+            {
                 "local_name": "C4S100IE?????",
                 "service_uuid": BMS.uuid_services()[0],
                 "connectable": True,
@@ -60,20 +50,17 @@ class BMS(VatrerBMS):
         await self._await_msg(
             BMS._cmd_modbus(dev_id=0x2, addr=0x0, count=BMS._REG_COUNT)
         )
-        if BMS._RESP_LEN not in self._msg:
+        if BMS._REG_COUNT * 2 not in self._msg:
             self._log.debug("incomplete data set %s", self._msg.keys())
-            raise TimeoutError("BMS data incomplete.")
+            raise ValueError("BMS data incomplete.")
 
-        result: BMSSample = BMS._decode_data(BMS._FIELDS, self._msg)
+        result: BMSSample = BMS._decode_data(BMS._FIELDS, self._msg[BMS._REG_COUNT * 2])
         result["cell_voltages"] = BMS._cell_voltages(
-            self._msg[BMS._RESP_LEN],
-            cells=result.get("cell_count", BMS._CELLS),
-            start=47,  # reg22
+            self._msg[BMS._REG_COUNT * 2], cells=result.get("cell_count", 0), start=47
         )
-        result["temp_sensors"] = BMS._TEMPS
         result["temp_values"] = BMS._temp_values(
-            self._msg[BMS._RESP_LEN],
-            start=35,  # reg16 (MOS_T), reg17 (ENV_T)
+            self._msg[BMS._REG_COUNT * 2],
+            start=35,
             values=BMS._TEMPS,
             types=(TempSensor.T.MOSFET, TempSensor.T.AMBIENT),
         )

--- a/aiobmsble/bms/c4s_bms.py
+++ b/aiobmsble/bms/c4s_bms.py
@@ -2,11 +2,18 @@
 
 Reverse-engineered from a 4S/100A LiFePO4 BMS sold under the local BLE name
 "C4S100IEnnnnn" (app: "E-BMS"), HW module RC6621A (Onmicro HS6621CM,
-transparent BLE-UART bridge). The application-level protocol is plain
-MODBUS RTU (slave id 0x02, function 0x03 - Read Holding Registers) carried
-transparently inside the Nordic UART Service. A single request for the 70
-holding registers starting at address 0x0000 returns the complete telemetry
-set (voltage, signed current, SOC, cell voltages, capacity, cycles, temps).
+transparent BLE-UART bridge). Shares the exact same transport layer and
+Modbus register map as VatrerBMS (slave id 0x02, function 0x03, Read
+Holding Registers over the Nordic UART Service) -- both are built around
+the same RC6621A-style bridge module -- so this implementation derives
+from VatrerBMS to reuse its transport-layer code as-is.
+
+The register *query pattern* differs, though: VatrerBMS reads the table in
+three separate partial requests ((0x0,0x14), (0x34,0x12), (0x15,0x1F)),
+while this device only responds to a single combined read of all 70
+holding registers (0x0, 0x46) -- verified against real hardware: sending
+VatrerBMS's three partial-range requests to this device produced no
+response at all for any of them, only the combined read works.
 
 Project: aiobmsble, https://pypi.org/p/aiobmsble/
 License: Apache-2.0, http://www.apache.org/licenses/
@@ -14,22 +21,22 @@ License: Apache-2.0, http://www.apache.org/licenses/
 
 from typing import Final
 
-from bleak.backends.characteristic import BleakGATTCharacteristic
-from bleak.backends.device import BLEDevice
-
-from aiobmsble import BMSConfig, BMSDp, BMSInfo, BMSSample, MatcherPattern, TempSensor
-from aiobmsble.basebms import BaseBMS, crc_modbus
+from aiobmsble import BMSDp, BMSInfo, BMSSample, MatcherPattern, TempSensor
+from aiobmsble.bms.vatrer_bms import BMS as VatrerBMS
 
 
-class BMS(BaseBMS):
-    """C4S100-family generic Modbus-over-BLE Smart BMS implementation."""
+class BMS(VatrerBMS):
+    """C4S100-family generic Modbus-over-BLE Smart BMS (derived from VatrerBMS).
+
+    Inherits the transport layer unchanged from VatrerBMS: uuid_services(),
+    uuid_rx(), uuid_tx(), _notification_handler(), _HEAD, _FRAME_LEN, and
+    __init__ are all identical between the two devices.
+    """
 
     INFO: BMSInfo = {
         "default_manufacturer": "Generic",
         "default_model": "C4S100 Smart BMS (RC6621A)",
     }
-    _HEAD: Final[bytes] = b"\x02\x03"  # slave id 0x02, function 0x03 (read holding regs)
-    _FRAME_LEN: Final[int] = 5  # head(2) + byte-count(1) + CRC(2)
     _CELLS: Final[int] = 4  # fixed 4S pack
     _TEMPS: Final[int] = 2  # 2 physical temp sensors (MOS_T, ENV_T); app mirrors
     #  them a second time as TCell1/TCell2 with identical values, not reported here
@@ -39,10 +46,10 @@ class BMS(BaseBMS):
     # BMSDp(key, pos, size, signed, fct, idx)
     # pos = byte offset within the full received frame (0=addr,1=func,2=byte-count,
     # 3.. = register data, big-endian, 2 bytes/register)
-    _FIELDS: Final[tuple[BMSDp, ...]] = (
+    _FIELDS: tuple[BMSDp, ...] = (
         BMSDp("voltage", 3, 2, False, lambda x: x / 100, _RESP_LEN),  # reg0
         # reg1 (hi word) + reg2 (lo word): signed 32-bit current, 0.01A,
-        # positive = charging, negative = discharging (matches app & library convention)
+        # positive = charging, negative = discharging
         BMSDp("current", 5, 4, True, lambda x: x / 100, _RESP_LEN),  # reg1+reg2
         BMSDp("battery_level", 9, 2, False, idx=_RESP_LEN),  # reg3, SOC %
         BMSDp("cycle_charge", 11, 2, False, lambda x: x / 100, _RESP_LEN),  # reg4, Ah
@@ -54,18 +61,8 @@ class BMS(BaseBMS):
         BMSDp("delta_voltage", 29, 2, False, lambda x: x / 1000, _RESP_LEN),  # reg13
         BMSDp("cell_count", 45, 2, False, idx=_RESP_LEN),  # reg21
     )
-    _RESPS: Final = frozenset(field.idx for field in _FIELDS)
-    _CMDS: Final[frozenset[tuple[int, int]]] = frozenset({(0x0, _REG_COUNT)})
-
-    def __init__(
-        self,
-        ble_device: BLEDevice,
-        config: BMSConfig | None = None,
-        logger_name: str = "",
-    ) -> None:
-        """Initialize private BMS members."""
-        super().__init__(ble_device, config, logger_name)
-        self._msg: dict[int, bytes] = {}
+    _RESPS = frozenset(field.idx for field in _FIELDS)
+    _CMDS: frozenset[tuple[int, int]] = frozenset({(0x0, _REG_COUNT)})
 
     @staticmethod
     def matcher_dict_list() -> list[MatcherPattern]:
@@ -77,47 +74,6 @@ class BMS(BaseBMS):
                 "connectable": True,
             }
         ]
-
-    @staticmethod
-    def uuid_services() -> tuple[str, ...]:
-        """Return list of 128-bit UUIDs of services required by BMS."""
-        return ("6e400001-b5a3-f393-e0a9-e50e24dcca9e",)
-
-    @staticmethod
-    def uuid_rx() -> str:
-        """Return 16-bit UUID of characteristic that provides notification/read property."""
-        return "6e400003-b5a3-f393-e0a9-e50e24dcca9e"
-
-    @staticmethod
-    def uuid_tx() -> str:
-        """Return 16-bit UUID of characteristic that provides write property."""
-        return "6e400002-b5a3-f393-e0a9-e50e24dcca9e"
-
-    def _notification_handler(
-        self, _sender: BleakGATTCharacteristic, data: bytearray
-    ) -> None:
-        """Handle the RX characteristics notify event (new data arrives)."""
-        self._log.debug("RX BLE data: %s", data)
-
-        if not data.startswith(BMS._HEAD):
-            self._log.debug("incorrect SOF")
-            return
-
-        if len(data) < BMS._FRAME_LEN or len(data) != data[2] + BMS._FRAME_LEN:
-            self._log.debug("incorrect frame length")
-            return
-
-        if not self._check_integrity(
-            data,
-            crc_modbus,
-            slice(None, -2),
-            slice(-2, None),
-            "little",
-        ):
-            return
-
-        self._msg[data[2]] = bytes(data)
-        self._msg_event.set()
 
     async def _async_update(self) -> BMSSample:
         """Update battery status information."""

--- a/aiobmsble/bms/c4s_bms.py
+++ b/aiobmsble/bms/c4s_bms.py
@@ -1,20 +1,5 @@
 """Module to support "C4S100"-family generic Modbus-over-BLE Smart BMS.
 
-Reverse-engineered from a 4S/100A LiFePO4 BMS sold under the local BLE name
-"C4S100IEnnnnn" (app: "E-BMS"), HW module RC6621A (Onmicro HS6621CM,
-transparent BLE-UART bridge). Shares the exact same transport layer and
-Modbus register map as VatrerBMS (slave id 0x02, function 0x03, Read
-Holding Registers over the Nordic UART Service) -- both are built around
-the same RC6621A-style bridge module -- so this implementation derives
-from VatrerBMS to reuse its transport-layer code as-is.
-
-The register *query pattern* differs, though: VatrerBMS reads the table in
-three separate partial requests ((0x0,0x14), (0x34,0x12), (0x15,0x1F)),
-while this device only responds to a single combined read of all 70
-holding registers (0x0, 0x46) -- verified against real hardware: sending
-VatrerBMS's three partial-range requests to this device produced no
-response at all for any of them, only the combined read works.
-
 Project: aiobmsble, https://pypi.org/p/aiobmsble/
 License: Apache-2.0, http://www.apache.org/licenses/
 """
@@ -30,7 +15,8 @@ class BMS(VatrerBMS):
 
     Inherits the transport layer unchanged from VatrerBMS: uuid_services(),
     uuid_rx(), uuid_tx(), _notification_handler(), _HEAD, _FRAME_LEN, and
-    __init__ are all identical between the two devices.
+    __init__ are all identical between the two devices. See
+    docs/c4s_bms.md for the full protocol writeup.
     """
 
     INFO: BMSInfo = {
@@ -38,31 +24,24 @@ class BMS(VatrerBMS):
         "default_model": "C4S100 Smart BMS (RC6621A)",
     }
     _CELLS: Final[int] = 4  # fixed 4S pack
-    _TEMPS: Final[int] = 2  # 2 physical temp sensors (MOS_T, ENV_T); app mirrors
-    #  them a second time as TCell1/TCell2 with identical values, not reported here
+    _TEMPS: Final[int] = 2  # 2 physical temp sensors (MOS_T, ENV_T), see docs
     _REG_COUNT: Final[int] = 0x46  # 70 holding registers polled in one request
     _RESP_LEN: Final[int] = _REG_COUNT * 2  # expected byte-count field (0x8C)
 
-    # BMSDp(key, pos, size, signed, fct, idx)
-    # pos = byte offset within the full received frame (0=addr,1=func,2=byte-count,
-    # 3.. = register data, big-endian, 2 bytes/register)
+    # BMSDp(key, pos, size, signed, fct, idx); pos/idx documented in docs/c4s_bms.md
     _FIELDS: tuple[BMSDp, ...] = (
-        BMSDp("voltage", 3, 2, False, lambda x: x / 100, _RESP_LEN),  # reg0
-        # reg1 (hi word) + reg2 (lo word): signed 32-bit current, 0.01A,
-        # positive = charging, negative = discharging
-        BMSDp("current", 5, 4, True, lambda x: x / 100, _RESP_LEN),  # reg1+reg2
-        BMSDp("battery_level", 9, 2, False, idx=_RESP_LEN),  # reg3, SOC %
-        BMSDp("cycle_charge", 11, 2, False, lambda x: x / 100, _RESP_LEN),  # reg4, Ah
+        BMSDp("voltage", 3, 2, False, lambda x: x / 100, _RESP_LEN),
+        BMSDp("current", 5, 4, True, lambda x: x / 100, _RESP_LEN),
+        BMSDp("battery_level", 9, 2, False, idx=_RESP_LEN),
+        BMSDp("cycle_charge", 11, 2, False, lambda x: x / 100, _RESP_LEN),
         BMSDp(
             "design_capacity", 13, 2, False, lambda x: round(x / 100), _RESP_LEN
-        ),  # reg5, Ah
-        BMSDp("cycles", 15, 2, False, idx=_RESP_LEN),  # reg6
-        BMSDp("battery_health", 17, 2, False, idx=_RESP_LEN),  # reg7, SOH %
-        BMSDp("delta_voltage", 29, 2, False, lambda x: x / 1000, _RESP_LEN),  # reg13
-        BMSDp("cell_count", 45, 2, False, idx=_RESP_LEN),  # reg21
+        ),
+        BMSDp("cycles", 15, 2, False, idx=_RESP_LEN),
+        BMSDp("battery_health", 17, 2, False, idx=_RESP_LEN),
+        BMSDp("delta_voltage", 29, 2, False, lambda x: x / 1000, _RESP_LEN),
+        BMSDp("cell_count", 45, 2, False, idx=_RESP_LEN),
     )
-    _RESPS = frozenset(field.idx for field in _FIELDS)
-    _CMDS: frozenset[tuple[int, int]] = frozenset({(0x0, _REG_COUNT)})
 
     @staticmethod
     def matcher_dict_list() -> list[MatcherPattern]:
@@ -78,9 +57,10 @@ class BMS(VatrerBMS):
     async def _async_update(self) -> BMSSample:
         """Update battery status information."""
         self._msg.clear()
-        for addr, length in BMS._CMDS:
-            await self._await_msg(BMS._cmd_modbus(dev_id=0x2, addr=addr, count=length))
-        if not BMS._RESPS.issubset(set(self._msg.keys())):
+        await self._await_msg(
+            BMS._cmd_modbus(dev_id=0x2, addr=0x0, count=BMS._REG_COUNT)
+        )
+        if BMS._RESP_LEN not in self._msg:
             self._log.debug("incomplete data set %s", self._msg.keys())
             raise TimeoutError("BMS data incomplete.")
 

--- a/aiobmsble/bms/vatrer_bms.py
+++ b/aiobmsble/bms/vatrer_bms.py
@@ -21,7 +21,10 @@ class BMS(BaseBMS):
     _FRAME_LEN: Final[int] = 5  # head + len + CRC
     _MAX_CELLS: Final[int] = 0x1F
     _MAX_TEMP: Final[int] = 6
-    _FIELDS: Final[tuple[BMSDp, ...]] = (
+    # not Final: derived classes (e.g. c4s_bms.py) with a different register
+    # query pattern need to override these, following the precedent set by
+    # RenogyBMS/RenogyProBMS.
+    _FIELDS: tuple[BMSDp, ...] = (
         BMSDp("voltage", 3, 2, False, lambda x: x / 100, 0x28),
         BMSDp("current", 5, 4, True, lambda x: x / 100, 0x28),
         BMSDp("battery_level", 9, 2, False, idx=0x28),
@@ -36,8 +39,8 @@ class BMS(BaseBMS):
         BMSDp("dischrg_mosfet", 32, 1, False, lambda x: bool(x & 0x20), 0x24),
         BMSDp("balancer", 35, 4, False, idx=0x24),
     )
-    _RESPS: Final = frozenset(field.idx for field in _FIELDS)
-    _CMDS: Final[frozenset[tuple[int, int]]] = frozenset(
+    _RESPS = frozenset(field.idx for field in _FIELDS)
+    _CMDS: frozenset[tuple[int, int]] = frozenset(
         {(0x0, 0x14), (0x34, 0x12), (0x15, 0x1F)}
     )
 

--- a/aiobmsble/bms/vatrer_bms.py
+++ b/aiobmsble/bms/vatrer_bms.py
@@ -21,9 +21,6 @@ class BMS(BaseBMS):
     _FRAME_LEN: Final[int] = 5  # head + len + CRC
     _MAX_CELLS: Final[int] = 0x1F
     _MAX_TEMP: Final[int] = 6
-    # not Final: derived classes (e.g. c4s_bms.py) with a different register
-    # query pattern need to override these, following the precedent set by
-    # RenogyBMS/RenogyProBMS.
     _FIELDS: tuple[BMSDp, ...] = (
         BMSDp("voltage", 3, 2, False, lambda x: x / 100, 0x28),
         BMSDp("current", 5, 4, True, lambda x: x / 100, 0x28),

--- a/aiobmsble/test_data/c4s_bms.json
+++ b/aiobmsble/test_data/c4s_bms.json
@@ -1,0 +1,16 @@
+[
+  {
+    "advertisement": {
+      "local_name": "C4S100IE06007",
+      "rssi": -74,
+      "service_uuids": [
+        "6e400001-b5a3-f393-e0a9-e50e24dcca9e"
+      ]
+    },
+    "type": "c4s_bms",
+    "_comments": [
+      "captured via bluetoothctl (BlueZ) from a real 4S/100A LiFePO4 BMS",
+      "random MAC, app: E-BMS, HW module: RC6621A (Onmicro HS6621CM)"
+    ]
+  }
+]

--- a/docs/c4s_bms.md
+++ b/docs/c4s_bms.md
@@ -1,0 +1,75 @@
+# C4S100-family generic Modbus-over-BLE Smart BMS
+
+## Hardware / protocol overview
+
+Reverse-engineered from a 4S/100A LiFePO4 BMS sold under the local BLE name
+`C4S100IEnnnnn` (companion app: **E-BMS**). The hardware is built around a
+generic RC6621A module (ShenZhen RF Crazy Technology, Onmicro HS6621CM
+chip), a transparent BLE-UART bridge — the app's traffic over the Nordic
+UART Service is a raw passthrough of the BMS's native **Modbus RTU**
+protocol (slave id `0x02`, function `0x03`, Read Holding Registers).
+
+A single request for the 70 holding registers starting at address
+`0x0000` returns the full telemetry set: pack voltage, signed current,
+SOC, cell voltages/count, remaining/nominal capacity, cycle count, SOH,
+cell voltage delta, and temperature.
+
+## Relation to VatrerBMS
+
+This device shares its exact register table with `VatrerBMS`: voltage,
+current, SOC, cycle_charge, cycles, delta_voltage, cell_count and
+cell_voltages all decode correctly using Vatrer's field offsets and
+scaling, verified byte-for-byte against real captured data.
+
+What differs is the **query pattern**. `VatrerBMS` reads the table via
+three separate partial requests: `(0x0,0x14)`, `(0x34,0x12)`,
+`(0x15,0x1F)`. This device does not respond to any of them — verified
+live against real hardware via `bluetoothctl` (notify enabled, all three
+requests sent in sequence): no notification arrived for any of the three.
+It only answers a single combined read of all 70 registers, `(0x0,
+0x46)`.
+
+Because of this, `C4SBMS` is implemented as `BMS(VatrerBMS)`, reusing the
+transport layer as-is (`uuid_services`, `uuid_rx`, `uuid_tx`,
+`_notification_handler`, `_HEAD`, `_FRAME_LEN`, `__init__`) and
+overriding only the register field map and the query/parsing method.
+
+## Register map
+
+| Register | Field | Encoding |
+|---|---|---|
+| reg0 | `voltage` | ×0.01 V |
+| reg1 (hi) + reg2 (lo) | `current` | signed 32-bit, ×0.01 A; positive = charging, negative = discharging |
+| reg3 | `battery_level` (SOC) | % |
+| reg4 | `cycle_charge` | ×0.01 Ah |
+| reg5 | `design_capacity` | ×0.01 Ah (100.00 Ah on the reference unit) |
+| reg6 | `cycles` | count |
+| reg7 | `battery_health` (SOH) | % |
+| reg13 | `delta_voltage` | mV, ÷1000 |
+| reg16 | MOS_T temperature | °C |
+| reg17 | ENV_T temperature | °C |
+| reg21 | `cell_count` | count (4 on the reference unit) |
+| reg22–25 | cell voltages | mV |
+
+The `(0x023D, 20)` request (not used by this implementation) decodes as
+ASCII `"EQ.V01.0.04"` — the firmware version string.
+
+## Temperature duplication
+
+The E-BMS app displays four temperature readings, but the device only has
+**two** physical sensors. Registers 16/17 (`MOS_T`/`ENV_T`) reappear a
+second time at registers 52–54 and 57–58 under different app labels
+(`TCell1`/`TCell2`), mirroring the same physical values. Only the first
+copy (reg16/17) is used by this implementation.
+
+## Known gaps
+
+- The status bits `chrg_mosfet`/`dischrg_mosfet`/`balancer`/`problem`
+  that `VatrerBMS` derives from its `(0x34,0x12)` block have no confirmed
+  ground truth on this device (never observed toggling in testing) and
+  are intentionally not reported, to avoid presenting unverified data as
+  real sensor state.
+- The status bitmask register for `CHGMOS`/`DSGMOS`/`Balancing`/`Fully`/
+  `Empty`/`Heating`/`LimitCurrent` shown in the app has not been located.
+  Locating it would require capturing a moment where one of those states
+  actually toggles.

--- a/docs/c4s_bms.md
+++ b/docs/c4s_bms.md
@@ -2,7 +2,7 @@
 
 ## Hardware / protocol overview
 
-Reverse-engineered from a 4S/100A LiFePO4 BMS sold under the local BLE name
+Derived from a 4S/100A LiFePO4 BMS sold under the local BLE name
 `C4S100IEnnnnn` (companion app: **E-BMS**). The hardware is built around a
 generic RC6621A module (ShenZhen RF Crazy Technology, Onmicro HS6621CM
 chip), a transparent BLE-UART bridge — the app's traffic over the Nordic

--- a/tests/bms/test_c4s.py
+++ b/tests/bms/test_c4s.py
@@ -1,4 +1,4 @@
-"""Test the C4S100-family BMS implementation."""
+"""Test the C4S100-family BMS implementation (derived from VatrerBMS)."""
 
 from collections.abc import Buffer
 from uuid import UUID

--- a/tests/bms/test_c4s.py
+++ b/tests/bms/test_c4s.py
@@ -13,16 +13,16 @@ from tests.conftest import MockBleakClient
 from tests.test_basebms import BMSBasicTests
 
 # real request/response pair, recorded from the device while discharging at ~-3.4A
-_REQ: bytes = bytes.fromhex("02 03 00 00 00 46 c4 0b")
-_RESP: bytes = bytes.fromhex(
-    "02 03 8c 05 35 ff ff fe aa 00 62 24 01 27 10 00 6b 00 62 00"
-    "01 00 00 00 00 0d 0b 0d 01 00 0a 00 04 00 03 00 1c 00 1b 00"
-    "01 00 00 00 00 00 04 0d 09 0d 02 0d 01 0d 0b 00 00 00 00 00"
-    "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00"
-    "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00"
-    "00 00 00 00 00 00 00 00 02 00 1b 00 1c 00 00 00 00 00 1b 00"
-    "1c 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 32 00 00 00"
-    "00 00 00 f4 2f"
+_REQ: bytes = b"\x02\x03\x00\x00\x00\x46\xc4\x0b"
+_RESP: bytes = (
+    b"\x02\x03\x8c\x05\x35\xff\xff\xfe\xaa\x00\x62\x24\x01\x27\x10\x00\x6b\x00\x62\x00"
+    b"\x01\x00\x00\x00\x00\x0d\x0b\x0d\x01\x00\x0a\x00\x04\x00\x03\x00\x1c\x00\x1b\x00"
+    b"\x01\x00\x00\x00\x00\x00\x04\x0d\x09\x0d\x02\x0d\x01\x0d\x0b\x00\x00\x00\x00\x00"
+    b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+    b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+    b"\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x1b\x00\x1c\x00\x00\x00\x00\x00\x1b\x00"
+    b"\x1c\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x32\x00\x00\x00"
+    b"\x00\x00\x00\xf4\x2f"
 )
 
 
@@ -91,46 +91,25 @@ async def test_update(patch_bleak_client, keep_alive_fixture: bool) -> None:
     await bms.disconnect()
 
 
-@pytest.fixture(
-    name="wrong_response",
-    params=[
-        (b"\x01\x03\x8c" + bytes(140) + b"\x00\x00", "wrong_SOF"),
-        (b"\x02\x03\x8c" + bytes(140) + b"\x00\x00\x00", "wrong_length"),
-        (b"\x02\x03\x8c" + bytes(140) + b"\x00\x00", "wrong_CRC"),
-        (b"\x02\x03\x21" + bytes(33) + b"\xba\x66", "wrong_type"),
-        (b"", "empty_frame"),
-    ],
-    ids=lambda param: param[1],
-)
-def fix_response(request: pytest.FixtureRequest) -> bytes:
-    """Return faulty response frame."""
-    assert isinstance(request.param, tuple) and isinstance(request.param[0], bytes)
-    return request.param[0]
-
-
-async def test_invalid_response(
+async def test_incomplete_data(
     monkeypatch: pytest.MonkeyPatch,
     patch_bleak_client,
     patch_bms_timeout,
-    wrong_response: bytes,
 ) -> None:
-    """Test data update with BMS returning invalid data."""
+    """Test data update when the BMS returns a validly-framed but wrong-size reply."""
 
     patch_bms_timeout()
 
     monkeypatch.setattr(
         MockC4SBleakClient,
         "RESP",
-        MockC4SBleakClient.RESP | {_REQ: wrong_response},
+        {_REQ: b"\x02\x03\x21" + bytes(33) + b"\xba\x66"},
     )
 
     patch_bleak_client(MockC4SBleakClient)
 
     bms = BMS(generate_ble_device())
-
-    result: BMSSample = {}
     with pytest.raises(TimeoutError):
-        result = await bms.async_update()
+        await bms.async_update()
 
-    assert not result
     await bms.disconnect()

--- a/tests/bms/test_c4s.py
+++ b/tests/bms/test_c4s.py
@@ -1,0 +1,136 @@
+"""Test the C4S100-family BMS implementation."""
+
+from collections.abc import Buffer
+from uuid import UUID
+
+from bleak.backends.characteristic import BleakGATTCharacteristic
+import pytest
+
+from aiobmsble import BMSConfig, BMSSample, TempSensor as TS
+from aiobmsble.bms.c4s_bms import BMS
+from tests.bluetooth import generate_ble_device
+from tests.conftest import MockBleakClient
+from tests.test_basebms import BMSBasicTests
+
+# real request/response pair, recorded from the device while discharging at ~-3.4A
+_REQ: bytes = bytes.fromhex("02 03 00 00 00 46 c4 0b")
+_RESP: bytes = bytes.fromhex(
+    "02 03 8c 05 35 ff ff fe aa 00 62 24 01 27 10 00 6b 00 62 00"
+    "01 00 00 00 00 0d 0b 0d 01 00 0a 00 04 00 03 00 1c 00 1b 00"
+    "01 00 00 00 00 00 04 0d 09 0d 02 0d 01 0d 0b 00 00 00 00 00"
+    "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00"
+    "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00"
+    "00 00 00 00 00 00 00 00 02 00 1b 00 1c 00 00 00 00 00 1b 00"
+    "1c 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 32 00 00 00"
+    "00 00 00 f4 2f"
+)
+
+
+def ref_value() -> BMSSample:
+    """Return reference value for mock C4S100 BMS (real captured discharge frame)."""
+    return {
+        "voltage": 13.33,
+        "current": -3.42,
+        "battery_level": 98,
+        "cycle_charge": 92.17,
+        "design_capacity": 100,
+        "cycles": 107,
+        "battery_health": 98,
+        "delta_voltage": 0.01,
+        "cell_count": 4,
+        "cell_voltages": [3.337, 3.33, 3.329, 3.339],
+        "temp_sensors": 2,
+        "temp_values": [TS(28.0, TS.T.MOSFET), TS(27.0, TS.T.AMBIENT)],
+        "battery_charging": False,
+        "temperature": 27.5,
+        "cycle_capacity": 1228.626,
+        "power": -45.589,
+        "runtime": 97021,
+        "problem": False,
+    }
+
+
+class TestBasicBMS(BMSBasicTests):
+    """Test the basic BMS functionality."""
+
+    bms_class = BMS
+
+
+class MockC4SBleakClient(MockBleakClient):
+    """Emulate a C4S100 BMS BleakClient."""
+
+    RESP: dict[bytes, bytes] = {_REQ: _RESP}
+
+    async def write_gatt_char(
+        self,
+        char_specifier: BleakGATTCharacteristic | int | str | UUID,
+        data: Buffer,
+        response: bool | None = None,
+    ) -> None:
+        """Issue write command to GATT."""
+        await super().write_gatt_char(char_specifier, data, response)
+        assert self._notify_callback is not None
+        self._notify_callback(
+            "MockC4SBleakClient", bytearray(self.RESP.get(bytes(data), b""))
+        )
+
+
+async def test_update(patch_bleak_client, keep_alive_fixture: bool) -> None:
+    """Test C4S100 BMS data update."""
+
+    patch_bleak_client(MockC4SBleakClient)
+
+    bms = BMS(generate_ble_device(), BMSConfig(keep_alive_fixture))
+
+    assert await bms.async_update() == ref_value()
+
+    # query again to check already connected state
+    await bms.async_update()
+    assert bms.is_connected is keep_alive_fixture
+
+    await bms.disconnect()
+
+
+@pytest.fixture(
+    name="wrong_response",
+    params=[
+        (b"\x01\x03\x8c" + bytes(140) + b"\x00\x00", "wrong_SOF"),
+        (b"\x02\x03\x8c" + bytes(140) + b"\x00\x00\x00", "wrong_length"),
+        (b"\x02\x03\x8c" + bytes(140) + b"\x00\x00", "wrong_CRC"),
+        (b"\x02\x03\x21" + bytes(33) + b"\xba\x66", "wrong_type"),
+        (b"", "empty_frame"),
+    ],
+    ids=lambda param: param[1],
+)
+def fix_response(request: pytest.FixtureRequest) -> bytes:
+    """Return faulty response frame."""
+    assert isinstance(request.param, tuple) and isinstance(request.param[0], bytes)
+    return request.param[0]
+
+
+async def test_invalid_response(
+    monkeypatch: pytest.MonkeyPatch,
+    patch_bleak_client,
+    patch_bms_timeout,
+    wrong_response: bytes,
+) -> None:
+    """Test data update with BMS returning invalid data."""
+
+    patch_bms_timeout()
+
+    monkeypatch.setattr(
+        MockC4SBleakClient,
+        "RESP",
+        MockC4SBleakClient.RESP | {_REQ: wrong_response},
+    )
+
+    patch_bleak_client(MockC4SBleakClient)
+
+    bms = BMS(generate_ble_device())
+
+    result: BMSSample = {}
+    with pytest.raises(TimeoutError):
+        result = await bms.async_update()
+
+    assert not result
+    await bms.disconnect()

--- a/tests/bms/test_c4s.py
+++ b/tests/bms/test_c4s.py
@@ -39,7 +39,6 @@ def ref_value() -> BMSSample:
         "delta_voltage": 0.01,
         "cell_count": 4,
         "cell_voltages": [3.337, 3.33, 3.329, 3.339],
-        "temp_sensors": 2,
         "temp_values": [TS(28.0, TS.T.MOSFET), TS(27.0, TS.T.AMBIENT)],
         "battery_charging": False,
         "temperature": 27.5,
@@ -109,7 +108,7 @@ async def test_incomplete_data(
     patch_bleak_client(MockC4SBleakClient)
 
     bms = BMS(generate_ble_device())
-    with pytest.raises(TimeoutError):
+    with pytest.raises(ValueError, match="BMS data incomplete."):
         await bms.async_update()
 
     await bms.disconnect()


### PR DESCRIPTION
## Summary

Adds a new plugin for a 4S/100A LiFePO4 BMS sold under the BLE local name
`C4S100IEnnnnn` (companion app: **E-BMS**). The hardware is built around a
generic RC6621A module (ShenZhen RF Crazy Technology, Onmicro HS6621CM
chip), a transparent BLE-UART bridge — the app's traffic over the Nordic
UART Service is a raw passthrough of the BMS's native **Modbus RTU**
protocol (slave id `0x02`, function `0x03`, Read Holding Registers).

A single request for the 70 holding registers starting at address
`0x0000` returns the full telemetry set needed by `BMSSample`: pack
voltage, signed current, SOC, cell voltages/count, remaining/nominal
capacity, cycle count, SOH, cell voltage delta, and 2 temperature
sensors (the app displays these same 2 physical sensors twice, under 4
different labels — `MOS_T`/`ENV_T` and `TCell1`/`TCell2`).

## Protocol verification

- CRC-16/Modbus (poly `0xA001`, init `0xFFFF`, little-endian on the wire)
  validated against **~1000 real captured frames** from two independent
  logging sessions (100% match, zero CRC failures).
- The full register map was cross-checked against the vendor app's own
  screenshots captured during a **controlled discharge → charge
  transition** on real hardware, to pin down the signed-current encoding
  and confirm exact matches for voltage, SOC, capacity, and cycle count.
- Verified working against real hardware (device advertises as
  `C4S100IE06007`) via Home Assistant's `bms_ble` integration.


<!--
  Thanks for contributing to this project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  This is simply a reminder of what I'm are going to look for before merging 
  your code. Please see the CONTRIBUTING.md for more information.
-->

### [Code Requirements][coding-guide]
- [x] There is no commented out code in this PR.
- [x] The code has been formatted according to Ruff. (`ruff check .`)
- [x] The code passes code quality checks of mypy. (`mypy .`)
- [x] The code passes spelling checks of codespell. (`codespell .`)

### [Architecture][architecture-guide] for new BMS types
- [x] The `BMSSample` structure is being filled with all available BMS data.
- [x] BMS frames are checked for validity, e.g. CRC, length, allowed type.
- [x] A recorded BLE advertisement has been added for testing.
- [x] The code does not require persistent values.

### Testing
- [x] Local tests pass and coverage is 100% branch.
- [x] Tests have been added to verify that the new code works.
- [x] Tests use recorded data from the BMS, i.e. test data shall not be generated.

### Contributing
- [x] Especially, for new BMSs, feel free to add your nickname to the `authors` list in `pyproject.toml`
- [x] I agree that the [project license][LICENSE] is used for my contribution

[contribution-guide]: https://github.com/patman15/aiobmsble/tree/main?tab=contributing-ov-file
[coding-guide]: https://github.com/patman15/aiobmsble/tree/main?tab=contributing-ov-file#coding-style-guidelines
[architecture-guide]: https://github.com/patman15/aiobmsble/tree/main?tab=contributing-ov-file#architecture-guidelines
[BMS-type]: https://github.com/patman15/aiobmsble/tree/main?tab=contributing-ov-file#how-to-qualify-as-a-bms
[LICENSE]: https://github.com/patman15/aiobmsble/blob/main/LICENSE
